### PR TITLE
Fix totals duplicating counts

### DIFF
--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -91,10 +91,12 @@ def get_linksearchtotal_data_by_time(queryset):
 def annotate_top(queryset, order_by, fields, num_results=None):
     queryset = queryset.values(
         *fields).annotate(
-        links_added=Count('change',
-                          filter=Q(change=LinkEvent.ADDED)),
-        links_removed=Count('change',
-                            filter=Q(change=LinkEvent.REMOVED))).order_by(
+        links_added=Count('pk',
+                          filter=Q(change=LinkEvent.ADDED),
+                          distinct=True),
+        links_removed=Count('pk',
+                            filter=Q(change=LinkEvent.REMOVED),
+                            distinct=True)).order_by(
         order_by
     )
     if num_results:
@@ -106,15 +108,17 @@ def annotate_top(queryset, order_by, fields, num_results=None):
 def top_organisations(org_list, linkevents, num_results=None):
     annotated_orgs = org_list.annotate(
         links_added=Count(
-            'collection__url__linkevent',
+            'collection__url__linkevent__pk',
             filter=Q(
                 collection__url__linkevent__in=linkevents,
-                collection__url__linkevent__change=LinkEvent.ADDED)),
+                collection__url__linkevent__change=LinkEvent.ADDED),
+            distinct=True),
         links_removed=Count(
-            'collection__url__linkevent',
+            'collection__url__linkevent__pk',
             filter=Q(
                 collection__url__linkevent__in=linkevents,
-                collection__url__linkevent__change=LinkEvent.REMOVED)),
+                collection__url__linkevent__change=LinkEvent.REMOVED),
+            distinct=True),
     ).order_by('-links_added')
     if num_results:
         return annotated_orgs[:5]

--- a/extlinks/common/tests.py
+++ b/extlinks/common/tests.py
@@ -1,0 +1,83 @@
+from django.test import TestCase
+
+from extlinks.links.factories import URLPatternFactory, LinkEventFactory
+from extlinks.links.models import LinkEvent
+from extlinks.organisations.factories import (OrganisationFactory,
+                                              CollectionFactory)
+from .helpers import annotate_top
+
+# Write tests for annotate_top to check what happens with (distinct'ed)
+# querysets, like we feed it currently, but where the underlying linkevents
+# have multiple collections. Is it returning the right numbers?
+
+
+class HelpersTest(TestCase):
+
+    def setUp(self):
+        self.org = OrganisationFactory()
+        collection = CollectionFactory(
+            organisation=self.org
+        )
+        collection2 = CollectionFactory(
+            organisation=self.org
+        )
+        self.url1 = URLPatternFactory(
+            url='foo.test.com',
+            collection=collection
+        )
+        self.url2 = URLPatternFactory(
+            url='test.com',
+            collection=collection2
+        )
+        self.event1 = LinkEventFactory(
+            link='test.com/url'
+        )
+        self.event1.url.add(self.url1)
+        self.event2 = LinkEventFactory(
+            link='test.com/url2'
+        )
+        self.event2.url.add(self.url1)
+        self.event3 = LinkEventFactory(
+            link='test.com/url3',
+            domain="de.wikipedia.org"
+        )
+        self.event3.url.add(self.url1)
+
+    def test_annotate_top_simple(self):
+        """
+        Make sure annotate_top sends back data in the expected format, given
+        some simple input.
+        """
+        queryset = LinkEvent.objects.filter(
+            url__collection__organisation__pk=self.org.pk
+        ).distinct()
+        annotate_results = annotate_top(queryset,
+                                        '-links_added',
+                                        ['domain'])
+        self.assertEqual(annotate_results[0], {'domain': "en.wikipedia.org",
+                         'links_added': 2, 'links_removed': 0})
+        self.assertEqual(annotate_results[1], {'domain': "de.wikipedia.org",
+                         'links_added': 1, 'links_removed': 0})
+
+    def test_annotate_top_multi_collection(self):
+        """
+        Make sure annotate_top sends back data in the expected format, when
+        we have LinkEvents that correspond to multiple URLPatterns in the same
+        organisation.
+        """
+        event4 = LinkEventFactory(
+            link='test.com/url4'
+        )
+        event4.url.add(self.url1)
+        event4.url.add(self.url2)
+        queryset = LinkEvent.objects.filter(
+            url__collection__organisation__pk=self.org.pk
+        ).distinct()
+        print(len(queryset), "events go in.")
+        annotate_results = annotate_top(queryset,
+                                        '-links_added',
+                                        ['domain'])
+        self.assertEqual(annotate_results[0], {'domain': "en.wikipedia.org",
+                         'links_added': 3, 'links_removed': 0})
+        self.assertEqual(annotate_results[1], {'domain': "de.wikipedia.org",
+                         'links_added': 1, 'links_removed': 0})

--- a/extlinks/common/views.py
+++ b/extlinks/common/views.py
@@ -40,7 +40,7 @@ class CSVOrgTotals(_CSVDownloadView):
             program__pk=program_pk)
         this_program_linkevents = LinkEvent.objects.filter(
             url__collection__organisation__program__pk=program_pk
-        )
+        ).distinct()
         this_program_linkevents = filter_queryset(this_program_linkevents,
                                                   self.request.GET)
         top_orgs = top_organisations(
@@ -59,7 +59,7 @@ class CSVPageTotals(_CSVDownloadView):
     def _write_data(self, response):
         org_pk = self.kwargs['pk']
         linkevents = LinkEvent.objects.filter(
-            url__collection__organisation__pk=org_pk)
+            url__collection__organisation__pk=org_pk).distinct()
 
         linkevents = filter_queryset(linkevents,
                                      self.request.GET)
@@ -84,10 +84,10 @@ class CSVProjectTotals(_CSVDownloadView):
         # If we came from an organisation page:
         if '/organisation' in self.request.build_absolute_uri():
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__pk=pk)
+                url__collection__organisation__pk=pk).distinct()
         else:
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__program__pk=pk)
+                url__collection__organisation__program__pk=pk).distinct()
 
         linkevents = filter_queryset(linkevents,
                                      self.request.GET)
@@ -110,10 +110,10 @@ class CSVUserTotals(_CSVDownloadView):
         # If we came from an organisation page:
         if '/organisation' in self.request.build_absolute_uri():
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__pk=pk)
+                url__collection__organisation__pk=pk).distinct()
         else:
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__program__pk=pk)
+                url__collection__organisation__program__pk=pk).distinct()
 
         linkevents = filter_queryset(linkevents,
                                      self.request.GET)
@@ -136,10 +136,10 @@ class CSVAllLinkEvents(_CSVDownloadView):
         # If we came from an organisation page:
         if '/organisation' in self.request.build_absolute_uri():
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__pk=pk)
+                url__collection__organisation__pk=pk).distinct()
         else:
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__program__pk=pk)
+                url__collection__organisation__program__pk=pk).distinct()
 
         linkevents = filter_queryset(linkevents,
                                      self.request.GET)

--- a/extlinks/links/factories.py
+++ b/extlinks/links/factories.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import factory
 import random
 
-from extlinks.organisations.factories import UserFactory
+from extlinks.organisations.factories import UserFactory, CollectionFactory
 from .models import LinkEvent, LinkSearchTotal, URLPattern
 
 
@@ -15,6 +15,8 @@ class URLPatternFactory(factory.django.DjangoModelFactory):
     # factory.Faker returns a Faker object by default, rather than str
     url = str(factory.Faker('url', schemes=['https']))[8:-1]
 
+    collection = factory.SubFactory(CollectionFactory)
+
 
 class LinkEventFactory(factory.django.DjangoModelFactory):
 
@@ -22,6 +24,8 @@ class LinkEventFactory(factory.django.DjangoModelFactory):
         model = LinkEvent
         strategy = factory.CREATE_STRATEGY
 
+    # We don't define any automatically generated link here, because it
+    # needs to directly correspond to the url field for this object too.
     timestamp = datetime.now()
     domain = "en.wikipedia.org"
     username = factory.SubFactory(UserFactory)
@@ -30,7 +34,7 @@ class LinkEventFactory(factory.django.DjangoModelFactory):
     page_title = factory.Faker('word')
     page_namespace = 0
     event_id = factory.Faker('uuid4')
-    change = random.choice([LinkEvent.ADDED, LinkEvent.REMOVED])
+    change = LinkEvent.ADDED
     on_user_list = False
 
 

--- a/extlinks/organisations/factories.py
+++ b/extlinks/organisations/factories.py
@@ -36,3 +36,4 @@ class CollectionFactory(factory.django.DjangoModelFactory):
         strategy = factory.CREATE_STRATEGY
 
     name = factory.Faker('word')
+    organisation = factory.SubFactory(OrganisationFactory)


### PR DESCRIPTION
We were overcounting in the case that a LinkEvent was part of multiple URLs. Added a test and fix for this.