### PR TITLE
Remove underscores from page titles

### DIFF
--- a/extlinks/common/templatetags/common_filters.py
+++ b/extlinks/common/templatetags/common_filters.py
@@ -1,0 +1,10 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def replace_underscores(string):
+    return string.replace('_', ' ')

--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load common_filters %}
 
 <div class="container-fluid">
     {% for key, collection in collections.items %}
@@ -103,7 +104,7 @@
                     {% for page in collection.top_pages %}
                         <tr>
                             <td>
-                                <a href="https://{{ page.domain }}/wiki/{{ page.page_title }}">{{ page.page_title|truncatechars:20 }}</a>
+                                <a href="https://{{ page.domain }}/wiki/{{ page.page_title }}">{{ page.page_title|replace_underscores|truncatechars:20 }}</a>
                             </td>
                             <td>
                                 {{ page.links_added }}
@@ -187,7 +188,7 @@
                     {% endif %}
                         <td><a href="{{ linkevent.link }}">{{ linkevent.link|truncatechars:50 }}</a></td>
                         <td><a href="https://{{ linkevent.domain }}/wiki/User:{{ linkevent.username }}">{{ linkevent.username|truncatechars:12 }}</a></td>
-                        <td><a href="https://{{ linkevent.domain }}/wiki/{{ linkevent.page_title }}">{{ linkevent.page_title|truncatechars:20 }}</a></td>
+                        <td><a href="https://{{ linkevent.domain }}/wiki/{{ linkevent.page_title }}">{{ linkevent.page_title|replace_underscores|truncatechars:20 }}</a></td>
                         <td>{{ linkevent.domain }}</td>
                         <td><a href="https://{{ linkevent.domain }}/wiki/Special:Diff/{{ linkevent.rev_id }}">{{ linkevent.timestamp }}</a></td>
                     </tr>

--- a/extlinks/programs/templates/programs/program_charts_include.html
+++ b/extlinks/programs/templates/programs/program_charts_include.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load common_filters %}
 
 <hr style="width: 100%;">
 <div class="container-fluid">
@@ -144,7 +145,7 @@
                 {% endif %}
                     <td><a href="{{ linkevent.link }}">{{ linkevent.link|truncatechars:50 }}</a></td>
                     <td><a href="https://{{ linkevent.domain }}/wiki/User:{{ linkevent.username }}">{{ linkevent.username|truncatechars:12 }}</a></td>
-                    <td><a href="https://{{ linkevent.domain }}/wiki/{{ linkevent.page_title }}">{{ linkevent.page_title|truncatechars:20 }}</a></td>
+                    <td><a href="https://{{ linkevent.domain }}/wiki/{{ linkevent.page_title }}">{{ linkevent.page_title|replace_underscores|truncatechars:20 }}</a></td>
                     <td>{{ linkevent.domain }}</td>
                     <td>
                         {% for organisation in linkevent.get_organisations %}


### PR DESCRIPTION
We could have done this with a model method but it wouldn't have worked so well with the top page annotations. Easier to make a catch-all custom filter.