### PR TITLE
Minor queryset optimisations

### DIFF
--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -289,9 +289,10 @@ def get_linkevent_context(context, queryset):
                                            ['domain'],
                                            num_results=5)
 
-    all_users = annotate_top(queryset,
-                             '-links_added',
-                             ['username__username'])
+    all_users = annotate_top(queryset.select_related(
+        'username'),
+        '-links_added',
+        ['username__username'])
     context['top_users'] = all_users[:5]
 
     context['latest_links'] = queryset.order_by(
@@ -310,7 +311,8 @@ def get_linkevent_context(context, queryset):
     context['total_removed'] = sum(removed_data_series)
     context['total_diff'] = context['total_added'] - context['total_removed']
 
-    context['total_editors'] = len(all_users)
+    context['total_editors'] = queryset.values_list(
+        'username').distinct().count()
     context['total_projects'] = queryset.values_list(
         'domain').distinct().count()
 

--- a/extlinks/programs/views.py
+++ b/extlinks/programs/views.py
@@ -31,8 +31,7 @@ class ProgramDetailView(DetailView):
         form = self.form_class(self.request.GET)
         context['form'] = form
 
-        this_program_linkevents = self.get_object().get_linkevents().select_related(
-            'username')
+        this_program_linkevents = self.get_object().get_linkevents()
 
         # Filter queryset based on form, if used
         if form.is_valid():


### PR DESCRIPTION
- Only `select_related` when we need it, rather than for every query.
- Use `.distinct().count()` on our original queryset instead of `len()` on a more complicated one.