### PR TITLE
extlinks: Add filter to remove bot edits

### DIFF
--- a/extlinks/common/forms.py
+++ b/extlinks/common/forms.py
@@ -23,4 +23,4 @@ class FilterForm(forms.Form):
                                    attrs={'class': 'form-control',
                                    'style': 'width: 6rem;'}))
 
-    bot_edits = forms.BooleanField(required=False)
+    exclude_bots = forms.BooleanField(required=False)

--- a/extlinks/common/forms.py
+++ b/extlinks/common/forms.py
@@ -22,3 +22,5 @@ class FilterForm(forms.Form):
                                widget=forms.NumberInput(
                                    attrs={'class': 'form-control',
                                    'style': 'width: 6rem;'}))
+
+    bot_edits = forms.BooleanField(required=False)

--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -241,11 +241,20 @@ def filter_queryset(queryset, filter_dict):
                 on_user_list=True
             )
 
+
     if 'namespace_id' in filter_dict:
         namespace_id = filter_dict['namespace_id']
         if namespace_id is not None:
             queryset = queryset.filter(
                 page_namespace=namespace_id
+            )
+
+
+    if 'bot_edits' in filter_dict:
+        bot_edits = filter_dict['bot_edits']
+        if bot_edits:
+            queryset = queryset.filter(
+                bot_edits=True
             )
 
     return queryset

--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -250,11 +250,11 @@ def filter_queryset(queryset, filter_dict):
             )
 
 
-    if 'bot_edits' in filter_dict:
-        bot_edits = filter_dict['bot_edits']
-        if bot_edits:
-            queryset = queryset.filter(
-                bot_edits=True
+    if 'exclude_bots' in filter_dict:
+        exclude_bots = filter_dict['exclude_bots']
+        if exclude_bots:
+            queryset = queryset.exclude(
+                user_is_bot=True
             )
 
     return queryset

--- a/extlinks/organisations/models.py
+++ b/extlinks/organisations/models.py
@@ -43,6 +43,13 @@ class Organisation(models.Model):
         else:
             return False
 
+    @property
+    def limit_by_bot(self):
+        if self.user_is_bot > 0:
+            return True
+        else:
+            return False
+
 
 class Collection(models.Model):
     class Meta:

--- a/extlinks/organisations/models.py
+++ b/extlinks/organisations/models.py
@@ -43,13 +43,6 @@ class Organisation(models.Model):
         else:
             return False
 
-    @property
-    def limit_by_bot(self):
-        if self.user_is_bot > 0:
-            return True
-        else:
-            return False
-
 
 class Collection(models.Model):
     class Meta:

--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -56,9 +56,25 @@
                                 </div>
                             {% endif %}
                             <div class="col">
+                                <butston type="submit" class="btn btn-primary">Submit</button>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            {% if object.limit_by_bot %}
+                                <div class="fieldWrapper" style="padding: 15px;">
+                                    {{ form.bot_edits.errors }}
+                                    {{ form.bot_edits.label_tag }} {{ form.bot_edits }}
+                                    {% if form.bot_edits.help_text %}
+                                        <p class="help">{{ form.bot_edits.help_text|safe }}</p>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                            <div class="col">
                                 <button type="submit" class="btn btn-primary">Submit</button>
                             </div>
                         </div>
+
                     </form>
                 </div>
             </div>

--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -55,10 +55,6 @@
                                     {% endif %}
                                 </div>
                             {% endif %}
-                            <div class="col">
-                                <butston type="submit" class="btn btn-primary">Submit</button>
-                            </div>
-                        </div>
                         <div class="form-row">
                             <div class="fieldWrapper" style="padding: 15px;">
                                 {{ form.exclude_bots.errors }}

--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -55,7 +55,6 @@
                                     {% endif %}
                                 </div>
                             {% endif %}
-                        <div class="form-row">
                             <div class="fieldWrapper" style="padding: 15px;">
                                 {{ form.exclude_bots.errors }}
                                 {{ form.exclude_bots.label_tag }} {{ form.exclude_bots }}

--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -59,22 +59,18 @@
                                 <butston type="submit" class="btn btn-primary">Submit</button>
                             </div>
                         </div>
-
                         <div class="form-row">
-                            {% if object.limit_by_bot %}
-                                <div class="fieldWrapper" style="padding: 15px;">
-                                    {{ form.bot_edits.errors }}
-                                    {{ form.bot_edits.label_tag }} {{ form.bot_edits }}
-                                    {% if form.bot_edits.help_text %}
-                                        <p class="help">{{ form.bot_edits.help_text|safe }}</p>
-                                    {% endif %}
-                                </div>
-                            {% endif %}
+                            <div class="fieldWrapper" style="padding: 15px;">
+                                {{ form.exclude_bots.errors }}
+                                {{ form.exclude_bots.label_tag }} {{ form.bot_edits }}
+                                {% if form.exclude_bots.help_text %}
+                                    <p class="help">{{ form.exclude_bots.help_text|safe }}</p>
+                                {% endif %}
+                            </div>
                             <div class="col">
                                 <button type="submit" class="btn btn-primary">Submit</button>
                             </div>
                         </div>
-
                     </form>
                 </div>
             </div>

--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -62,7 +62,7 @@
                         <div class="form-row">
                             <div class="fieldWrapper" style="padding: 15px;">
                                 {{ form.exclude_bots.errors }}
-                                {{ form.exclude_bots.label_tag }} {{ form.bot_edits }}
+                                {{ form.exclude_bots.label_tag }} {{ form.exclude_bots }}
                                 {% if form.exclude_bots.help_text %}
                                     <p class="help">{{ form.exclude_bots.help_text|safe }}</p>
                                 {% endif %}

--- a/extlinks/organisations/tests.py
+++ b/extlinks/organisations/tests.py
@@ -282,3 +282,20 @@ class OrganisationDetailTest(TestCase):
         self.assertContains(response, self.linkevent4.link)
 
         self.assertContains(response, self.linkevent1.username.username)
+
+    def test_bot_edits_form(self):
+        """
+        Test that the bot list limiting form works on the organisation detail page.
+        """
+        factory = RequestFactory()
+
+        data = {
+            'bot_edits': True
+        }
+
+        request = factory.get(self.url1, data)
+        response = OrganisationDetailView.as_view()(request,
+                                                    pk=self.organisation1.pk)
+
+        self.assertEqual(response.context_data['collections'][self.collection1_key]['total_added'], 1)
+        self.assertEqual(response.context_data['collections'][self.collection1_key]['total_removed'], 0)

--- a/extlinks/organisations/tests.py
+++ b/extlinks/organisations/tests.py
@@ -71,7 +71,8 @@ class OrganisationDetailTest(TestCase):
             change=LinkEvent.ADDED,
             username=user,
             timestamp=datetime(2019, 1, 15),
-            page_title="Event 1")
+            page_title="Event 1",
+            user_is_bot=True)
         self.linkevent1.url.add(urlpattern1)
         self.linkevent1.save()
 
@@ -297,5 +298,5 @@ class OrganisationDetailTest(TestCase):
         response = OrganisationDetailView.as_view()(request,
                                                     pk=self.organisation1.pk)
 
-        self.assertEqual(response.context_data['collections'][self.collection1_key]['total_added'], 1)
-        self.assertEqual(response.context_data['collections'][self.collection1_key]['total_removed'], 0)
+        self.assertEqual(response.context_data['collections'][self.collection1_key]['total_added'], 2)
+        self.assertEqual(response.context_data['collections'][self.collection1_key]['total_removed'], 1)

--- a/extlinks/organisations/tests.py
+++ b/extlinks/organisations/tests.py
@@ -290,7 +290,7 @@ class OrganisationDetailTest(TestCase):
         factory = RequestFactory()
 
         data = {
-            'bot_edits': True
+            'exclude_bots': True
         }
 
         request = factory.get(self.url1, data)

--- a/extlinks/programs/models.py
+++ b/extlinks/programs/models.py
@@ -40,3 +40,14 @@ class Program(models.Model):
             return True
         else:
             return False
+
+    @property
+    def any_orgs_bot_edits(self):
+        program_orgs = Organisation.objects.filter(
+            program=self,
+            user_is_bot__isnull=False)
+
+        if program_orgs.count() > 0:
+            return True
+        else:
+            return False

--- a/extlinks/programs/models.py
+++ b/extlinks/programs/models.py
@@ -40,14 +40,3 @@ class Program(models.Model):
             return True
         else:
             return False
-
-    @property
-    def any_orgs_bot_edits(self):
-        program_orgs = Organisation.objects.filter(
-            program=self,
-            user_is_bot__isnull=False)
-
-        if program_orgs.count() > 0:
-            return True
-        else:
-            return False

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -57,6 +57,22 @@
                                 <button type="submit" class="btn btn-primary">Submit</button>
                             </div>
                         </div>
+
+
+                        <div class="form-row">
+                            {% if program.any_orgs_user_list %}
+                                <div class="fieldWrapper" style="padding: 15px;">
+                                    {{ form.bot_edits.errors }}
+                                    {{ form.bot_edits.label_tag }} {{ form.bot_edits }}
+                                    {% if form.bot_edits.help_text %}
+                                        <p class="help">{{ form.bot_edits.help_text|safe }}</p>
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                            <div class="col">
+                                <button type="submit" class="btn btn-primary">Submit</button>
+                            </div>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -52,9 +52,6 @@
                                         <p class="help">{{ form.limit_to_user_list.help_text|safe }}</p>
                                     {% endif %}
                                 </div>
-                                <div class="col">
-                                    <button type="submit" class="btn btn-primary">Submit</button>
-                                </div>
                              {% endif %}
                         </div>
                         <div class="form-row">

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -44,31 +44,25 @@
                             </div>
                         </div>
                         <div class="form-row">
-                            {% if program.any_orgs_user_list %}
-                                <div class="fieldWrapper" style="padding: 15px;">
-                                    {{ form.limit_to_user_list.errors }}
-                                    {{ form.limit_to_user_list.label_tag }} {{ form.limit_to_user_list }}
-                                    {% if form.limit_to_user_list.help_text %}
-                                        <p class="help">{{ form.limit_to_user_list.help_text|safe }}</p>
-                                    {% endif %}
-                                </div>
-                            {% endif %}
+                            <div class="fieldWrapper" style="padding: 15px;">
+                                {{ form.limit_to_user_list.errors }}
+                                {{ form.limit_to_user_list.label_tag }} {{ form.limit_to_user_list }}
+                                {% if form.limit_to_user_list.help_text %}
+                                    <p class="help">{{ form.limit_to_user_list.help_text|safe }}</p>
+                                {% endif %}
+                            </div>
                             <div class="col">
                                 <button type="submit" class="btn btn-primary">Submit</button>
                             </div>
                         </div>
-
-
                         <div class="form-row">
-                            {% if program.any_orgs_user_list %}
-                                <div class="fieldWrapper" style="padding: 15px;">
-                                    {{ form.bot_edits.errors }}
-                                    {{ form.bot_edits.label_tag }} {{ form.bot_edits }}
-                                    {% if form.bot_edits.help_text %}
-                                        <p class="help">{{ form.bot_edits.help_text|safe }}</p>
-                                    {% endif %}
-                                </div>
-                            {% endif %}
+                            <div class="fieldWrapper" style="padding: 15px;">
+                                {{ form.exclude_bots.errors }}
+                                {{ form.exclude_bots.label_tag }} {{ form.exclude_bots }}
+                                {% if form.exclude_bots.help_text %}
+                                    <p class="help">{{ form.exclude_bots.help_text|safe }}</p>
+                                {% endif %}
+                            </div>
                             <div class="col">
                                 <button type="submit" class="btn btn-primary">Submit</button>
                             </div>

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -44,16 +44,18 @@
                             </div>
                         </div>
                         <div class="form-row">
-                            <div class="fieldWrapper" style="padding: 15px;">
-                                {{ form.limit_to_user_list.errors }}
-                                {{ form.limit_to_user_list.label_tag }} {{ form.limit_to_user_list }}
-                                {% if form.limit_to_user_list.help_text %}
-                                    <p class="help">{{ form.limit_to_user_list.help_text|safe }}</p>
-                                {% endif %}
-                            </div>
-                            <div class="col">
-                                <button type="submit" class="btn btn-primary">Submit</button>
-                            </div>
+                            {% if program.any_orgs_user_list %}
+                                <div class="fieldWrapper" style="padding: 15px;">
+                                    {{ form.limit_to_user_list.errors }}
+                                    {{ form.limit_to_user_list.label_tag }} {{ form.limit_to_user_list }}
+                                    {% if form.limit_to_user_list.help_text %}
+                                        <p class="help">{{ form.limit_to_user_list.help_text|safe }}</p>
+                                    {% endif %}
+                                </div>
+                                <div class="col">
+                                    <button type="submit" class="btn btn-primary">Submit</button>
+                                </div>
+                             {% endif %}
                         </div>
                         <div class="form-row">
                             <div class="fieldWrapper" style="padding: 15px;">

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -53,8 +53,6 @@
                                     {% endif %}
                                 </div>
                              {% endif %}
-                        </div>
-                        <div class="form-row">
                             <div class="fieldWrapper" style="padding: 15px;">
                                 {{ form.exclude_bots.errors }}
                                 {{ form.exclude_bots.label_tag }} {{ form.exclude_bots }}

--- a/extlinks/programs/tests.py
+++ b/extlinks/programs/tests.py
@@ -286,3 +286,20 @@ class ProgramDetailTest(TestCase):
         self.assertContains(response, self.linkevent4.link)
 
         self.assertContains(response, self.linkevent1.username.username)
+
+    def test_program_detail_bot_edits(self):
+        """
+        Test that the user list limiting form works on the program detail page.
+        """
+        factory = RequestFactory()
+
+        data = {
+            'bot_edits': True
+        }
+
+        request = factory.get(self.url1, data)
+        response = ProgramDetailView.as_view()(request,
+                                               pk=self.program1.pk)
+
+        self.assertEqual(response.context_data['total_added'], 1)
+        self.assertEqual(response.context_data['total_removed'], 0)

--- a/extlinks/programs/tests.py
+++ b/extlinks/programs/tests.py
@@ -294,7 +294,7 @@ class ProgramDetailTest(TestCase):
         factory = RequestFactory()
 
         data = {
-            'bot_edits': True
+            'exclude_bots': True
         }
 
         request = factory.get(self.url1, data)

--- a/extlinks/programs/tests.py
+++ b/extlinks/programs/tests.py
@@ -75,7 +75,8 @@ class ProgramDetailTest(TestCase):
             change=LinkEvent.ADDED,
             username=user,
             timestamp=datetime(2019, 1, 15),
-            page_title="Event 1")
+            page_title="Event 1",
+            user_is_bot=True)
         self.linkevent1.url.add(urlpattern1)
         self.linkevent1.save()
 
@@ -301,5 +302,5 @@ class ProgramDetailTest(TestCase):
         response = ProgramDetailView.as_view()(request,
                                                pk=self.program1.pk)
 
-        self.assertEqual(response.context_data['total_added'], 1)
-        self.assertEqual(response.context_data['total_removed'], 0)
+        self.assertEqual(response.context_data['total_added'], 2)
+        self.assertEqual(response.context_data['total_removed'], 1)


### PR DESCRIPTION
Change is added to remove bot edits within programs and organisations. Reviewers can test code
through extlinks/programs/tests.py and extlinks/organisations/tests.py

Bug: T228384