### PR TITLE
Change Django requirements

### DIFF
--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,4 +1,4 @@
-Django==2.2.3
+Django>=2.2.13,<3.0
 django_cron==0.5.1
 factory_boy==2.11.1
 faker==1.0.5


### PR DESCRIPTION
Changed Django requirements to always install the latest version of
Django 2.2 instead of a fixed one.