### PR TITLE
Default behaviour should be getting historical data

### DIFF
--- a/Dockerfile-eventstream
+++ b/Dockerfile-eventstream
@@ -11,4 +11,4 @@ RUN mkdir logs
 
 RUN pip install -r django.txt
 
-CMD ["python", "manage.py", "linkevents_collect"]
+CMD ["python", "manage.py", "linkevents_collect", "--historical"]


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to Wikilinks (externallinks)!)

## Description
The `--historical` flag ensures that the eventstream collection script goes back to the last date in the database to construct the stream URL and ensure complete data coverage. For some reason I'd left that flag out here and edited it back in manually in production.

## Rationale
This will ensure that when we stand the production server up historical data will be collected as expected.

## Phabricator Ticket
n/a

## How Has This Been Tested?
I haven't tested this but this is exactly how it currently stands in production:
![image](https://user-images.githubusercontent.com/12038840/90876152-18dfa480-e39a-11ea-85aa-e9baa52f3d29.png)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
