### PR TITLE
Track proxied URLs + refactor/test link tracking

### DIFF
--- a/extlinks/links/helpers.py
+++ b/extlinks/links/helpers.py
@@ -1,3 +1,8 @@
+from urllib.parse import unquote
+
+from .models import URLPattern
+
+
 def split_url_for_query(url):
     """
     Given a URL pattern, split it into two components:
@@ -20,3 +25,40 @@ def split_url_for_query(url):
         url_pattern_end = '%'
 
     return url_optimised, url_pattern_end
+
+
+def link_is_tracked(link):
+    all_urlpatterns = URLPattern.objects.all()
+    tracked_links_list = list(all_urlpatterns.values_list('url', flat=True))
+    proxied_url = False
+
+    # If this looks like a TWL proxied URL we're going to need to match
+    # it against a longer list of strings
+    if "wikipedialibrary.idm.oclc" in link:
+        proxied_url = True
+        proxied_urls = [urlpattern.get_proxied_url
+                        for urlpattern in all_urlpatterns]
+        tracked_links_list.extend(proxied_urls)
+
+    # This is a quick check so we can filter the majority of events
+    # which won't be matching our filters
+    if any(links in link for links in tracked_links_list):
+        # Then we do a more detailed check, to make sure this is the
+        # root URL.
+        for tracked_link in tracked_links_list:
+            # If we track apa.org, we don't want to match iaapa.org
+            # so we make sure the URL is actually pointing at apa.org
+            url_starts = ["//" + tracked_link, "." + tracked_link]
+            if proxied_url:
+                # Proxy URLs may contain //www- not //www.
+                url_starts.append("-" + tracked_link)
+
+            # We want to avoid link additions from e.g. InternetArchive
+            # where the URL takes the structure
+            # https://web.archive.org/https://test.com/
+            protocol_count = link.count("//")
+
+            if any(start in link for start in url_starts) and protocol_count < 2:
+                return True
+    else:
+        return False

--- a/extlinks/links/models.py
+++ b/extlinks/links/models.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 from django.db import models
+from django.utils.functional import cached_property
 
 
 class URLPattern(models.Model):
@@ -18,6 +19,12 @@ class URLPattern(models.Model):
 
     def __str__(self):
         return self.url
+
+    @cached_property
+    def get_proxied_url(self):
+        # This isn't everything that happens, but it's good enough
+        # for us to make a decision about whether we have a match.
+        return self.url.replace(".", "-")
 
 
 class LinkSearchTotal(models.Model):

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -4,8 +4,8 @@ from django.test import TestCase
 from extlinks.organisations.factories import (OrganisationFactory,
                                               CollectionFactory)
 from .factories import LinkEventFactory, URLPatternFactory
-from .helpers import split_url_for_query
-from .models import LinkEvent
+from .helpers import link_is_tracked, split_url_for_query
+from .models import URLPattern
 
 
 class LinksHelpersTest(TestCase):
@@ -64,3 +64,93 @@ class LinksHelpersTest(TestCase):
         new_link.url.add(urlpattern3)
 
         self.assertEqual(new_link.get_organisation, organisation2)
+
+    def test_link_is_tracked_true(self):
+        """
+        Test that link_is_tracked returns True when we have a matching
+        URLPattern
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertTrue(link_is_tracked("https://test.com/testurl"))
+
+    def test_link_is_tracked_true_with_subdomain(self):
+        """
+        Test that link_is_tracked returns True when we have a matching
+        URLPattern even when the link has a subdomain
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertTrue(link_is_tracked("https://foo.test.com/testurl"))
+
+    def test_link_is_tracked_true_with_www(self):
+        """
+        Test that link_is_tracked returns True when we have a matching
+        URLPattern even when the link has www
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertTrue(link_is_tracked("https://www.test.com/testurl"))
+
+    def test_link_is_tracked_false(self):
+        """
+        Test that link_is_tracked returns False when we have no matching
+        URLPattern
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertFalse(link_is_tracked("https://www.foo.com/"))
+
+    def test_link_is_tracked_false_not_domain(self):
+        """
+        Test that link_is_tracked returns False when we have a partial
+        match but the match isn't for the actual domain
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertFalse(link_is_tracked("https://thisisatest.com/"))
+
+    def test_link_is_tracked_false_archive(self):
+        """
+        Test that link_is_tracked returns False when we have a partial
+        match based on multiple protocols
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertFalse(link_is_tracked("https://web.archive.org/https://test.com/"))
+
+    def test_link_is_tracked_true_proxy(self):
+        """
+        Test that link_is_tracked returns True when we have a proxied URL
+        that matches a URLPattern
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertTrue(link_is_tracked("https://www-test-com.wikipedialibrary.idm.oclc.org/"))
+
+    def test_link_is_tracked_false_other_proxy(self):
+        """
+        Test that link_is_tracked returns False when we have a proxied URL
+        that matches our URLPattern but isn't the TWL proxy
+        """
+        _ = URLPatternFactory(url="test.com")
+
+        self.assertFalse(link_is_tracked("https://www-test-com.university.idm.oclc.org/"))
+
+
+class URLPatternModelTest(TestCase):
+    def test_get_proxied_url_1(self):
+        """
+        Test that URLPattern.get_proxied_url transforms a URL correctly
+        """
+        test_urlpattern = URLPattern(url="gale.com")
+        self.assertEqual(test_urlpattern.get_proxied_url, "gale-com")
+
+    def test_get_proxied_url_2(self):
+        """
+        Test that URLPattern.get_proxied_url transforms a URL correctly
+        when it has a subdomain
+        """
+        test_urlpattern = URLPattern(url="platform.almanhal.com")
+        self.assertEqual(test_urlpattern.get_proxied_url,
+                         "platform-almanhal-com")

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -65,13 +65,17 @@ class LinksHelpersTest(TestCase):
 
         self.assertEqual(new_link.get_organisation, organisation2)
 
+
+class LinksTrackedTest(TestCase):
+
+    def setUp(self):
+        _ = URLPatternFactory(url="test.com")
+
     def test_link_is_tracked_true(self):
         """
         Test that link_is_tracked returns True when we have a matching
         URLPattern
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertTrue(link_is_tracked("https://test.com/testurl"))
 
     def test_link_is_tracked_true_with_subdomain(self):
@@ -79,8 +83,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns True when we have a matching
         URLPattern even when the link has a subdomain
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertTrue(link_is_tracked("https://foo.test.com/testurl"))
 
     def test_link_is_tracked_true_with_www(self):
@@ -88,8 +90,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns True when we have a matching
         URLPattern even when the link has www
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertTrue(link_is_tracked("https://www.test.com/testurl"))
 
     def test_link_is_tracked_false(self):
@@ -97,8 +97,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns False when we have no matching
         URLPattern
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertFalse(link_is_tracked("https://www.foo.com/"))
 
     def test_link_is_tracked_false_not_domain(self):
@@ -106,8 +104,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns False when we have a partial
         match but the match isn't for the actual domain
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertFalse(link_is_tracked("https://thisisatest.com/"))
 
     def test_link_is_tracked_false_archive(self):
@@ -115,8 +111,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns False when we have a partial
         match based on multiple protocols
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertFalse(link_is_tracked("https://web.archive.org/https://test.com/"))
 
     def test_link_is_tracked_true_proxy(self):
@@ -124,8 +118,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns True when we have a proxied URL
         that matches a URLPattern
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertTrue(link_is_tracked("https://www-test-com.wikipedialibrary.idm.oclc.org/"))
 
     def test_link_is_tracked_false_other_proxy(self):
@@ -133,8 +125,6 @@ class LinksHelpersTest(TestCase):
         Test that link_is_tracked returns False when we have a proxied URL
         that matches our URLPattern but isn't the TWL proxy
         """
-        _ = URLPatternFactory(url="test.com")
-
         self.assertFalse(link_is_tracked("https://www-test-com.university.idm.oclc.org/"))
 
 


### PR DESCRIPTION
## Description
This change does three things:

- Adds tracking of Wikipedia Library proxied versions of URLs so that if a user adds a citation to, for example, `https://www-test-com.wikipedialibrary.idm.oclc.org/`, we track it if we're tracking `test.com`
- Refactors the tracking script so that it's easier to work with and test
- Adds tests for the logic that decides whether we care about tracking a particular URL, which was notably missing.

## Rationale
We're currently missing a substantial amount of links being added by editors who add proxied versions of the URL in their citation. That's not inherently a problem because there's a bot that tidies those up afterwards on-wiki, but we want to know that we tracked them using our resources.

## Phabricator Ticket
https://phabricator.wikimedia.org/T262025

## How Has This Been Tested?
I added a set of new tests covering both the new change and the previously expected behaviour.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
