### PR TITLE
delete backups older than 90 days.

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -23,6 +23,11 @@ flock -n ${lockfile}
         chmod 0600 "/app/backup/${date}.sql.gz"
 
         echo "Finished backup."
+
+        # Retain backups for 90 days.
+        find /app/backup -name "*.sql.gz" -mtime +90 -delete || :
+
+        echo "Removed backups created 90 days ago or more."
     else
         exit 1
     fi


### PR DESCRIPTION
## Description
We should retain backups for 90 days. This automatically deletes old backups. The worlds tiniest PR.

## Rationale
The primary concern here is disk usage. Currently, the disk usage will increase indefinitely.

## Phabricator Ticket
https://phabricator.wikimedia.org/T254327

## How Has This Been Tested?

- I created a backup `202009301535.sql.gz` and then set it's modification time to be older than 90 days by running `touch -m --date="2020-01-01 00:00" backup/202009301535.sql.gz`
- I then deleted the gzip binary from the running image.
- I ran another backup, which failed. The backup script has the `-e` option set, meaning that if the db dump fails, the old backups should not be deleted.
- The old backup was still there.
- I then halted and deleted that container and reran `docker-compose up` and ran another backup.
- A new backup was created successfully and the old backup was deleted. Backups less than 90 days old remained.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
