### PR TITLE
Configure SSE Client retry and timeout behavior.

### DIFF
--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -48,17 +48,17 @@ class Command(BaseCommand):
         # Eventsource should fail if it can't read data after ~15 minutes.
         for event in EventSource(
             url,
-            # The retry argument sets the delay between retries in milliseconds.
-            # We're setting this to 5 minutes.
-            # There's no way to set the max_retries value with this library,
-            # but since it depends upon requests, which in turn uses urllib3
-            # by default, we get a default max_retries value of 3.
+         """The retry argument sets the delay between retries in milliseconds.
+             We're setting this to 5 minutes.
+            There's no way to set the max_retries value with this library,
+            but since it depends upon requests, which in turn uses urllib3
+            by default, we get a default max_retries value of 3."""
             retry=300000,
-            # The timeout argument gets passed to requests.get.
-            # An integer value sets connect (socket connect) and
-            # read (time to first byte / since last byte) timeout values.
-            # A tuple value sets each respective value independently.
-            # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+            """The timeout argument gets passed to requests.get.
+            An integer value sets connect (socket connect) and
+            read (time to first byte / since last byte) timeout values.
+            A tuple value sets each respective value independently.
+            https://requests.readthedocs.io/en/latest/user/advanced/#timeouts"""
             timeout=(3.05, 30),
         ):
             if event.event == 'message':

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -45,7 +45,22 @@ class Command(BaseCommand):
         else:
             url = base_stream_url
 
-        for event in EventSource(url):
+        # Eventsource should fail if it can't read data after ~15 minutes.
+        for event in EventSource(
+            url,
+            # The retry argument sets the delay between retries in milliseconds.
+            # We're setting this to 5 minutes.
+            # There's no way to set the max_retries value with this library,
+            # but since it depends upon requests, which in turn uses urllib3
+            # by default, we get a default max_retries value of 3.
+            retry=300000,
+            # The timeout argument gets passed to requests.get.
+            # An integer value sets connect (socket connect) and
+            # read (time to first byte / since last byte) timeout values.
+            # A tuple value sets each respective value independently.
+            # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
+            timeout=(3.05, 30),
+        ):
             if event.event == 'message':
                 try:
                     event_data = json.loads(event.data)

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         for event in EventSource(
             url,
          """The retry argument sets the delay between retries in milliseconds.
-             We're setting this to 5 minutes.
+            We're setting this to 5 minutes.
             There's no way to set the max_retries value with this library,
             but since it depends upon requests, which in turn uses urllib3
             by default, we get a default max_retries value of 3."""

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             but since it depends upon requests, which in turn uses urllib3
             by default, we get a default max_retries value of 3."""
             retry=300000,
-            """The timeout argument gets passed to requests.get.
+         """The timeout argument gets passed to requests.get.
             An integer value sets connect (socket connect) and
             read (time to first byte / since last byte) timeout values.
             A tuple value sets each respective value independently.


### PR DESCRIPTION
## Description
Adds timeout and retry delay values to SSE client in linkevent collection command.

## Rationale
Currently, the evenstream container hangs on a regular basis. This should allow the container to either time out and retry or fail out so that docker swarm can restart it.

## Phabricator Ticket
https://phabricator.wikimedia.org/T264211

## How Has This Been Tested?
Ran `docker exec -it $(docker ps -aq -f name=staging_externallinks | head -n 1) python manage.py linkevents_collect --historical` on staging and it didn't blow up. I can't really test any further unless we discover why the eventstream container almost immediately exits in non-production environments.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
