### PR TITLE
Add Django Debug Toolbar to local dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ __pycache__/
 *.pyc
 
 static/admin
+static/debug_toolbar
 
 db.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@
 FROM python:3.8-buster as eventstream
 
 WORKDIR /app
-COPY requirements/django.txt /app/
-RUN pip install -r django.txt
+ARG REQUIREMENTS_FILE
+ENV REQUIREMENTS_FILE=${REQUIREMENTS_FILE:-django.txt}
+COPY requirements/* /app/
+RUN echo "Installing $REQUIREMENTS_FILE" && pip install -r $REQUIREMENTS_FILE
 RUN apt update && apt install -y default-mysql-client && rm -rf /var/lib/apt/lists/*
 # This file only exists once the code directory is mounted by docker-compose.
 ENTRYPOINT ["/app/bin/django_wait_for_db.sh"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The tool uses the [Django framework](https://www.djangoproject.com/) and is depl
 
 After cloning the repository to your directory of choice:
 1. Copy `template.env` to `.env`. No further changes are required for local development.
-2. Run `docker-compose up -d --build` to build containers.
+2. Run `docker-compose up -d --build` to build containers. If you want to enable the [Django Debug Toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/index.html), you should run `docker-compose build --build-arg REQUIREMENTS_FILE=local.txt && docker-compose up`
 3. The `eventstream` container will fail to build on the first run, so it will need to be restarted with `docker restart externallinks_eventstream_1`
 
 You should now be able to access the tool via `localhost`.

--- a/extlinks/settings/local.py
+++ b/extlinks/settings/local.py
@@ -5,3 +5,28 @@ DEBUG = True
 
 SERVER_EMAIL = "Wikilink Local <wikilink.local@localhost.localdomain>"
 DEFAULT_FROM_EMAIL = SERVER_EMAIL
+
+
+# Django Debug Toolbar config
+# ------------------------------------------------------------------------------
+
+# Sometimes, developers do not want the debug toolbar on their local environments,
+# so we can disable it by not passing a REQUIREMENTS_FILE variable when building
+# the docker containers
+if os.environ["REQUIREMENTS_FILE"] == "local.txt":
+    INSTALLED_APPS += [
+        "debug_toolbar",
+    ]
+
+    MIDDLEWARE += [
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+    ]
+
+    INTERNAL_IPS = ["127.0.0.1", "localhost", "0.0.0.0"]
+
+    def show_toolbar(request):
+        return True
+
+    DEBUG_TOOLBAR_CONFIG = {
+        "SHOW_TOOLBAR_CALLBACK": show_toolbar,
+    }

--- a/extlinks/urls.py
+++ b/extlinks/urls.py
@@ -1,5 +1,7 @@
+import os
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
 
 from extlinks.programs.urls import urlpatterns as programs_urls
 from extlinks.organisations.urls import urlpatterns as organisations_urls
@@ -7,12 +9,19 @@ from extlinks.organisations.urls import urlpatterns as organisations_urls
 from .views import Homepage, Documentation
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', Homepage.as_view(), name='homepage'),
-    path('docs', Documentation.as_view(), name='documentation'),
-
-    path('programs/', include((programs_urls, 'programs'),
-                              namespace='programs')),
-    path('organisations/', include((organisations_urls, 'organisations'),
-                                   namespace='organisations'))
+    path("admin/", admin.site.urls),
+    path("", Homepage.as_view(), name="homepage"),
+    path("docs", Documentation.as_view(), name="documentation"),
+    path("programs/", include((programs_urls, "programs"), namespace="programs")),
+    path(
+        "organisations/",
+        include((organisations_urls, "organisations"), namespace="organisations"),
+    ),
 ]
+
+if settings.DEBUG and os.environ["REQUIREMENTS_FILE"] == "local.txt":
+    import debug_toolbar
+
+    urlpatterns += [
+        path("__debug__/", include(debug_toolbar.urls)),
+    ]

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,0 +1,2 @@
+-r django.txt 
+django-debug-toolbar==3.1.1


### PR DESCRIPTION
## Description
Added the Django Debug Toolbar library.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This library will help us with debugging issues, such as the one described in [T240673](https://phabricator.wikimedia.org/T240673)

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
 [T240673](https://phabricator.wikimedia.org/T240673)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Run `docker-compose build && docker-compose up`. This shouldn't display the Django Debug Toolbar.
2. Run `docker-compose build --build-arg REQUIREMENTS_FILE=local.txt && docker-compose up`. This should display the Django Debug Toolbar.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
**Docker build with a REQUIREMENTS_FILE arg**
![Screen Shot 2020-10-01 at 12 20 54](https://user-images.githubusercontent.com/7854953/94842131-a1f9ea80-03e0-11eb-9969-a5100f5fc46f.png)

**Docker build without a REQUIREMENTS_FILE arg**
![Screen Shot 2020-10-01 at 12 21 56](https://user-images.githubusercontent.com/7854953/94842195-b8a04180-03e0-11eb-97be-5b3e56fcd81e.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
