### PR TITLE
WIP Replace docker.io with quay.io for wikilink images

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -15,15 +15,18 @@ jobs:
   mirror:
     runs-on: ubuntu-latest
     steps:
-      - name: Pull docker.io/library/python
+      - name: Pull and retag docker.io library images
         run: |
           docker pull docker.io/library/python:3.8-buster
           docker tag docker.io/library/python:3.8-buster quay.io/wikipedialibrary/python:3.8-buster
+          docker pull docker.io/library/nginx:latest
+          docker tag docker.io/library/nginx:latest quay.io/wikipedialibrary/nginx:latest
       - name: Log into quay.io
         run: echo "${{ secrets.CR_PASSWORD }}" | docker login quay.io -u ${{ secrets.CR_USERNAME }} --password-stdin
-      - name: Push python image to quay.io/wikipedialibrary/python
+      - name: Push docker.io library images to quay.io/wikipedialibrary
         run: |
           docker push quay.io/wikipedialibrary/python:3.8-buster
+          docker push quay.io/wikipedialibrary/nginx:latest
 
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -11,9 +11,25 @@ on:
   pull_request:
 
 jobs:
+  # Mirror docker.io/library/python to quay.io/wikipedialibrary/python
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull docker.io/library/python
+        run: |
+          docker pull docker.io/library/python:3.8-buster
+          docker tag docker.io/library/python:3.8-buster quay.io/wikipedialibrary/python:3.8-buster
+      - name: Log into quay.io
+        run: echo "${{ secrets.CR_PASSWORD }}" | docker login quay.io -u ${{ secrets.CR_USERNAME }} --password-stdin
+      - name: Push python image to quay.io/wikipedialibrary/python
+        run: |
+          docker push quay.io/wikipedialibrary/python:3.8-buster
+
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
+    # Ensure latest python image is mirrored before running tests.
+    needs: mirror
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Load eventstream image
         run: docker load -i eventstream.tar.gz
 
-      - name: Log into Docker Hub
+      - name: Log into quay.io
         run: echo "${{ secrets.CR_PASSWORD }}" | docker login quay.io -u ${{ secrets.CR_USERNAME }} --password-stdin
 
       - name: Set branch tag

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -21,12 +21,15 @@ jobs:
           docker tag docker.io/library/python:3.8-buster quay.io/wikipedialibrary/python:3.8-buster
           docker pull docker.io/library/nginx:latest
           docker tag docker.io/library/nginx:latest quay.io/wikipedialibrary/nginx:latest
+          docker pull docker.io/library/mysql:5.7
+          docker tag docker.io/library/mysql:5.7 quay.io/wikipedialibrary/mysql:5.7
       - name: Log into quay.io
         run: echo "${{ secrets.CR_PASSWORD }}" | docker login quay.io -u ${{ secrets.CR_USERNAME }} --password-stdin
       - name: Push docker.io library images to quay.io/wikipedialibrary
         run: |
           docker push quay.io/wikipedialibrary/python:3.8-buster
           docker push quay.io/wikipedialibrary/nginx:latest
+          docker push quay.io/wikipedialibrary/mysql:5.7
 
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -23,6 +23,8 @@ jobs:
           docker tag docker.io/library/nginx:latest quay.io/wikipedialibrary/nginx:latest
           docker pull docker.io/library/mysql:5.7
           docker tag docker.io/library/mysql:5.7 quay.io/wikipedialibrary/mysql:5.7
+          docker pull docker.io/library/memcached:latest
+          docker tag docker.io/library/memcached:latest quay.io/wikipedialibrary/memcached:latest
       - name: Log into quay.io
         run: echo "${{ secrets.CR_PASSWORD }}" | docker login quay.io -u ${{ secrets.CR_USERNAME }} --password-stdin
       - name: Push docker.io library images to quay.io/wikipedialibrary
@@ -30,6 +32,7 @@ jobs:
           docker push quay.io/wikipedialibrary/python:3.8-buster
           docker push quay.io/wikipedialibrary/nginx:latest
           docker push quay.io/wikipedialibrary/mysql:5.7
+          docker push quay.io/wikipedialibrary/memcached:latest
 
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -26,7 +26,7 @@ jobs:
           docker-compose exec -T externallinks /app/bin/django_wait_for_db.sh python django_wait_for_migrations.py test
       - name: Save externallinks image
         run: |
-          docker save wikipedialibrary/externallinks:latest | gzip > externallinks.tar.gz
+          docker save quay.io/wikipedialibrary/externallinks:latest | gzip > externallinks.tar.gz
       - name: upload externallinks image
         uses: actions/upload-artifact@v2
         with:
@@ -34,7 +34,7 @@ jobs:
           path: externallinks.tar.gz
       - name: Save eventstream image
         run: |
-          docker save wikipedialibrary/eventstream:latest | gzip > eventstream.tar.gz
+          docker save quay.io/wikipedialibrary/eventstream:latest | gzip > eventstream.tar.gz
       - name: upload eventstream image
         uses: actions/upload-artifact@v2
         with:
@@ -70,7 +70,7 @@ jobs:
         run: docker load -i eventstream.tar.gz
 
       - name: Log into Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        run: echo "${{ secrets.CR_PASSWORD }}" | docker login quay.io -u ${{ secrets.CR_USERNAME }} --password-stdin
 
       - name: Set branch tag
         id: branch
@@ -100,7 +100,7 @@ jobs:
       - name: Push externallinks image
         run: |
           # The image name represents both the local image name and the remote image repository.
-          image_name=wikipedialibrary/externallinks
+          image_name=quay.io/wikipedialibrary/externallinks
           branch_tag=${{ steps.branch.outputs.tag }}
           commit_tag=${{ steps.commit.outputs.tag }}
 
@@ -112,7 +112,7 @@ jobs:
       - name: Push eventstream image
         run: |
           # The image name represents both the local image name and the remote image repository.
-          image_name=wikipedialibrary/eventstream
+          image_name=quay.io/wikipedialibrary/eventstream
           branch_tag=${{ steps.branch.outputs.tag }}
           commit_tag=${{ steps.commit.outputs.tag }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.8-buster as eventstream
+FROM quay.io/wikipedialibrary/python:3.8-buster as eventstream
 
 WORKDIR /app
 ARG REQUIREMENTS_FILE

--- a/bin/swarm_update.sh
+++ b/bin/swarm_update.sh
@@ -49,8 +49,8 @@ then
 fi
 
 # Pull image updates.
-pull wikipedialibrary/externallinks ${externallinks_tag}
-pull wikipedialibrary/eventstream ${eventstream_tag}
+pull quay.io/wikipedialibrary/externallinks ${externallinks_tag}
+pull quay.io/wikipedialibrary/eventstream ${eventstream_tag}
 
 # Update repository for updates to code or to the swarm deployment itself.
 git -C ${dir} pull

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
    volumes:
      - ./:/app
  cache:
-   image: memcached
+   image: quay.io/wikipedialibrary/memcached:latest
    ports:
     - "11211:11211"
    entrypoint:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
      interval: 10s
      retries: 10
  nginx:
-   image: nginx
+   image: quay.io/wikipedialibrary/nginx:latest
    volumes:
      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
      - ./static:/app/static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
    volumes:
      - ./:/app
  db:
-   image: mysql:5.7
+   image: quay.io/wikipedialibrary/mysql:5.7
    env_file:
      - '.env'
    ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
  externallinks:
-   image: wikipedialibrary/externallinks:${EXTERNALLINKS_TAG}
+   image: quay.io/wikipedialibrary/externallinks:${EXTERNALLINKS_TAG}
    build:
      context: .
      target: externallinks
@@ -42,7 +42,7 @@ services:
    depends_on:
      - externallinks
  eventstream:
-   image: wikipedialibrary/eventstream:${EVENTSTREAM_TAG}
+   image: quay.io/wikipedialibrary/eventstream:${EVENTSTREAM_TAG}
    build:
      context: .
      target: eventstream


### PR DESCRIPTION
## Description
Replace docker.io with quay.io for wikilink images.

## Rationale
The newly enforced docker hub pull rate limits make our deployment pipeline too unpredictable
https://www.docker.com/increase-rate-limits

## Phabricator Ticket
https://phabricator.wikimedia.org/T270082

## How Has This Been Tested?
Our testing capabilities on this are limited since this is an in-band change to our deployment infrastructure.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
