### PR TITLE
Show Net Change only in Total tables

### DIFF
--- a/extlinks/common/templates/common/statistics_table.html
+++ b/extlinks/common/templates/common/statistics_table.html
@@ -1,0 +1,98 @@
+<h4>Statistics</h4>
+{% if collections %}
+  <table style="width:90%; margin-top: 30px;">
+      <tr class="stat-table-header">
+          <td>Link events</td>
+      </tr>
+      <tr>
+          <td>Total added:</td>
+          <td style="text-align: right;">{{ collection.total_added }}</td>
+      </tr>
+      <tr>
+          <td>Total removed:</td>
+          <td style="text-align: right;">{{ collection.total_removed }}</td>
+      </tr>
+      <tr style="line-height:55px;">
+          <td></td>
+          <td style="text-align: right; font-weight: bold;
+              {% if collection.total_diff > 0 %}
+                      color: green;">+
+              {% else %}
+                      color: red;">
+              {% endif %}
+              {{ collection.total_diff }}
+          </td>
+      </tr>
+      {% if collection.linksearch_total_start %}
+        <tr class="stat-table-header">
+          <td>Total links (Wikipedia only)</td>
+        </tr>
+        <tr>
+          <td>{{ collection.linksearch_start_date }}:</td>
+          <td style="text-align: right;">{{ collection.linksearch_total_start }}</td>
+        </tr>
+        <tr>
+          <td>Current total:</td>
+          <td style="text-align: right;">{{ collection.linksearch_total_current }}</td>
+        </tr>
+        <tr style="line-height:55px;">
+          <td></td>
+          <td style="text-align: right; font-weight: bold;
+              {% if collection.linksearch_total_diff > 0 %}
+                      color: green;">+
+              {% else %}
+                      color: red;">
+              {% endif %}
+              {{ collection.linksearch_total_diff }}
+          </td>
+        </tr>
+      {% endif %}
+      <tr class="stat-table-header">
+        <td>Other</td>
+      </tr>
+      <tr>
+        <td>Total editors:</td>
+        <td style="text-align: right;">{{ collection.total_editors }}</td>
+      </tr>
+      <tr>
+        <td>Total projects:</td>
+        <td style="text-align: right;">{{ collection.total_projects }}</td>
+      </tr>
+  </table>
+{% else %}
+  <table style="width:90%; margin-top: 30px;">
+      <tr class="stat-table-header">
+        <td>Link events</td>
+      </tr>
+      <tr>
+        <td>Total added:</td>
+        <td style="text-align: right;">{{ total_added }}</td>
+      </tr>
+      <tr>
+        <td>Total removed:</td>
+        <td style="text-align: right;">{{ total_removed }}</td>
+      </tr>
+      <tr style="line-height:55px;">
+        <td></td>
+        <td style="text-align: right; font-weight: bold;
+            {% if total_diff > 0 %}
+                    color: green;">+
+            {% else %}
+                    color: red;">
+            {% endif %}
+            {{ total_diff }}
+        </td>
+      </tr>
+      <tr class="stat-table-header">
+        <td>Other</td>
+      </tr>
+      <tr>
+        <td>Total editors:</td>
+        <td style="text-align: right;">{{ total_editors }}</td>
+      </tr>
+      <tr>
+        <td>Total projects:</td>
+        <td style="text-align: right;">{{ total_projects }}</td>
+      </tr>
+  </table>
+{% endif %}

--- a/extlinks/common/templates/common/top_organisations_table.html
+++ b/extlinks/common/templates/common/top_organisations_table.html
@@ -1,0 +1,17 @@
+{% load common_filters %}
+<table class="table">
+  <tr>
+    <th>Organisation</th>
+    <th>Net Change</th>
+  </tr>
+  {% for organisation in top_organisations %}
+    <tr>
+      <td>
+        <a href="{% url 'organisations:detail' pk=organisation.organisation__pk %}?{{ query_string }}">{{ organisation.organisation__name|truncatechars:20 }}</a>
+      </td>
+      <td>
+        {{ organisation.links_diff }}
+      </td>
+    </tr>
+  {% endfor %}
+</table>

--- a/extlinks/common/templates/common/top_organisations_table.html
+++ b/extlinks/common/templates/common/top_organisations_table.html
@@ -2,7 +2,7 @@
 <table class="table">
   <tr>
     <th>Organisation</th>
-    <th>Net Change</th>
+    <th>Added Links</th>
   </tr>
   {% for organisation in top_organisations %}
     <tr>

--- a/extlinks/common/templates/common/top_pages_table.html
+++ b/extlinks/common/templates/common/top_pages_table.html
@@ -2,7 +2,7 @@
 <table class="table">
     <tr>
       <th>Page</th>
-      <th>Net Change</th>
+      <th>Added Links</th>
     </tr>
     {% for page in collection.top_pages %}
       <tr>

--- a/extlinks/common/templates/common/top_pages_table.html
+++ b/extlinks/common/templates/common/top_pages_table.html
@@ -1,0 +1,17 @@
+{% load common_filters %}
+<table class="table">
+    <tr>
+      <th>Page</th>
+      <th>Net Change</th>
+    </tr>
+    {% for page in collection.top_pages %}
+      <tr>
+        <td>
+          <a href="https://{{ page.project_name }}/wiki/{{ page.page_name }}">{{ page.page_name|replace_underscores|truncatechars:20 }}</a>
+        </td>
+        <td>
+          {{ page.links_diff }}
+        </td>
+      </tr>
+    {% endfor %}
+</table>

--- a/extlinks/common/templates/common/top_projects_table.html
+++ b/extlinks/common/templates/common/top_projects_table.html
@@ -1,0 +1,29 @@
+<table class="table">
+    <tr>
+      <th>Project</th>
+      <th>Net Change</th>
+    </tr>
+    {% if collections %}
+      {% for project in collection.top_projects %}
+        <tr>
+          <td>
+            {{ project.project_name }}
+          </td>
+          <td>
+            {{ project.links_diff }}
+          </td>
+        </tr>
+      {% endfor %}
+    {% else %}
+      {% for project in top_projects %}
+        <tr>
+          <td>
+            {{ project.project_name }}
+          </td>
+          <td>
+            {{ project.links_diff }}
+          </td>
+        </tr>
+      {% endfor %}
+    {% endif %}
+</table>

--- a/extlinks/common/templates/common/top_projects_table.html
+++ b/extlinks/common/templates/common/top_projects_table.html
@@ -1,7 +1,7 @@
 <table class="table">
     <tr>
       <th>Project</th>
-      <th>Net Change</th>
+      <th>Added Links</th>
     </tr>
     {% if collections %}
       {% for project in collection.top_projects %}

--- a/extlinks/common/templates/common/top_users_table.html
+++ b/extlinks/common/templates/common/top_users_table.html
@@ -1,7 +1,7 @@
 <table class="table">
     <tr>
       <th>Username</th>
-      <th>Net Change</th>
+      <th>Added Links</th>
     </tr>
     {% if collections %}
       {% for user in collection.top_users %}

--- a/extlinks/common/templates/common/top_users_table.html
+++ b/extlinks/common/templates/common/top_users_table.html
@@ -1,0 +1,30 @@
+<table class="table">
+    <tr>
+      <th>Username</th>
+      <th>Net Change</th>
+    </tr>
+    {% if collections %}
+      {% for user in collection.top_users %}
+        <tr>
+          <td>
+            <a href="https://meta.wikimedia.org/wiki/User:{{ user.username }}">{{ user.username|truncatechars:15 }}</a>
+          </td>
+          <td>
+            {{ user.links_diff }}
+          </td>
+        </tr>
+      {% endfor %}
+    {% else %}
+      {% for user in top_users %}
+        <tr>
+          <td>
+            <a href="https://meta.wikimedia.org/wiki/User:{{ user.username }}">{{ user.username|truncatechars:15 }}</a>
+          </td>
+          <td>
+            {{ user.links_diff }}
+          </td>
+        </tr>
+      {% endfor %}
+    {% endif %}
+
+</table>

--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -28,66 +28,7 @@
         </div>
       </div>
     <div class="col-3 stat-box">
-        <h4>Statistics</h4>
-        <table style="width:90%; margin-top: 30px;">
-            <tr class="stat-table-header">
-                <td>Link events</td>
-            </tr>
-            <tr>
-                <td>Total added:</td>
-                <td style="text-align: right;">{{ collection.total_added }}</td>
-            </tr>
-            <tr>
-                <td>Total removed:</td>
-                <td style="text-align: right;">{{ collection.total_removed }}</td>
-            </tr>
-            <tr style="line-height:55px;">
-                <td></td>
-                <td style="text-align: right; font-weight: bold;
-                    {% if collection.total_diff > 0 %}
-                            color: green;">+
-                    {% else %}
-                            color: red;">
-                    {% endif %}
-                    {{ collection.total_diff }}
-                </td>
-            </tr>
-            {% if collection.linksearch_total_start %}
-              <tr class="stat-table-header">
-                <td>Total links (Wikipedia only)</td>
-              </tr>
-              <tr>
-                <td>{{ collection.linksearch_start_date }}:</td>
-                <td style="text-align: right;">{{ collection.linksearch_total_start }}</td>
-              </tr>
-              <tr>
-                <td>Current total:</td>
-                <td style="text-align: right;">{{ collection.linksearch_total_current }}</td>
-              </tr>
-              <tr style="line-height:55px;">
-                <td></td>
-                <td style="text-align: right; font-weight: bold;
-                    {% if collection.linksearch_total_diff > 0 %}
-                            color: green;">+
-                    {% else %}
-                            color: red;">
-                    {% endif %}
-                    {{ collection.linksearch_total_diff }}
-                </td>
-              </tr>
-            {% endif %}
-            <tr class="stat-table-header">
-              <td>Other</td>
-            </tr>
-            <tr>
-              <td>Total editors:</td>
-              <td style="text-align: right;">{{ collection.total_editors }}</td>
-            </tr>
-            <tr>
-              <td>Total projects:</td>
-              <td style="text-align: right;">{{ collection.total_projects }}</td>
-            </tr>
-        </table>
+      {% include "common/statistics_table.html" %}
     </div>
     </div>
     <div class="row" style="margin-top:40px;">
@@ -95,64 +36,19 @@
     </div>
     <div class="row">
       <div class="col-4">
-        <table class="table">
-            <tr>
-              <th>Page</th>
-              <th>Net Change</th>
-            </tr>
-            {% for page in collection.top_pages %}
-              <tr>
-                <td>
-                  <a href="https://{{ page.project_name }}/wiki/{{ page.page_name }}">{{ page.page_name|replace_underscores|truncatechars:20 }}</a>
-                </td>
-                <td>
-                  {{ page.links_diff }}
-                </td>
-              </tr>
-            {% endfor %}
-        </table>
+        {% include "common/top_pages_table.html" %}
         <div style="text-align:right;">
           <a href="{% url 'organisations:csv_page_totals' pk=collection.object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
         </div>
       </div>
       <div class="col-4">
-        <table class="table">
-          <tr>
-            <th>Project</th>
-            <th>Net Change</th>
-          </tr>
-          {% for project in collection.top_projects %}
-            <tr>
-              <td>
-                {{ project.project_name }}
-              </td>
-              <td>
-                {{ project.links_diff }}
-              </td>
-            </tr>
-          {% endfor %}
-        </table>
+        {% include "common/top_projects_table.html" %}
         <div style="text-align:right;">
           <a href="{% url 'organisations:csv_project_totals' pk=collection.object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
         </div>
       </div>
       <div class="col-4">
-        <table class="table">
-          <tr>
-            <th>Username</th>
-            <th>Net Change</th>
-          </tr>
-          {% for user in collection.top_users %}
-            <tr>
-              <td>
-                <a href="https://meta.wikimedia.org/wiki/User:{{ user.username }}">{{ user.username|truncatechars:15 }}</a>
-              </td>
-              <td>
-                {{ user.links_diff }}
-              </td>
-            </tr>
-          {% endfor %}
-        </table>
+        {% include "common/top_users_table.html" %}
         <div style="text-align:right;">
           <a href="{% url 'organisations:csv_user_totals' pk=collection.object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
         </div>

--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -98,20 +98,12 @@
         <table class="table">
             <tr>
               <th>Page</th>
-              <th>Added</th>
-              <th>Removed</th>
               <th>Net Change</th>
             </tr>
             {% for page in collection.top_pages %}
               <tr>
                 <td>
                   <a href="https://{{ page.project_name }}/wiki/{{ page.page_name }}">{{ page.page_name|replace_underscores|truncatechars:20 }}</a>
-                </td>
-                <td>
-                  {{ page.links_added }}
-                </td>
-                <td>
-                  {{ page.links_removed }}
                 </td>
                 <td>
                   {{ page.links_diff }}
@@ -127,20 +119,12 @@
         <table class="table">
           <tr>
             <th>Project</th>
-            <th>Added</th>
-            <th>Removed</th>
             <th>Net Change</th>
           </tr>
           {% for project in collection.top_projects %}
             <tr>
               <td>
                 {{ project.project_name }}
-              </td>
-              <td>
-                {{ project.links_added }}
-              </td>
-              <td>
-                {{ project.links_removed }}
               </td>
               <td>
                 {{ project.links_diff }}
@@ -156,20 +140,12 @@
         <table class="table">
           <tr>
             <th>Username</th>
-            <th>Added</th>
-            <th>Removed</th>
             <th>Net Change</th>
           </tr>
           {% for user in collection.top_users %}
             <tr>
               <td>
                 <a href="https://meta.wikimedia.org/wiki/User:{{ user.username }}">{{ user.username|truncatechars:15 }}</a>
-              </td>
-              <td>
-                {{ user.links_added }}
-              </td>
-              <td>
-                {{ user.links_removed }}
               </td>
               <td>
                 {{ user.links_diff }}

--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -272,33 +272,27 @@ class OrganisationDetailView(DetailView):
             PageProjectAggregate.objects.filter(queryset_filter)
             .values("project_name")
             .annotate(
-                links_added=Sum("total_links_added"),
-                links_removed=Sum("total_links_removed"),
                 links_diff=Sum("total_links_added") - Sum("total_links_removed"),
             )
-            .order_by("-links_diff", "-links_added", "-links_removed")
+            .order_by("-links_diff")
         )[:5]
 
         context["top_pages"] = (
             PageProjectAggregate.objects.filter(queryset_filter)
             .values("project_name", "page_name")
             .annotate(
-                links_added=Sum("total_links_added"),
-                links_removed=Sum("total_links_removed"),
                 links_diff=Sum("total_links_added") - Sum("total_links_removed"),
             )
-            .order_by("-links_diff", "-links_added", "-links_removed")
+            .order_by("-links_diff")
         )[:5]
 
         context["top_users"] = (
             UserAggregate.objects.filter(queryset_filter)
             .values("username")
             .annotate(
-                links_added=Sum("total_links_added"),
-                links_removed=Sum("total_links_removed"),
                 links_diff=Sum("total_links_added") - Sum("total_links_removed"),
             )
-            .order_by("-links_diff", "-links_added", "-links_removed")
+            .order_by("-links_diff")
         )[:5]
 
         return context

--- a/extlinks/programs/templates/programs/program_charts_include.html
+++ b/extlinks/programs/templates/programs/program_charts_include.html
@@ -8,42 +8,7 @@
       <canvas id="eventStreamChart" width="700" height="400"></canvas>
     </div>
     <div class="col-3 stat-box">
-      <h4>Statistics</h4>
-      <table style="width:90%; margin-top: 30px;">
-          <tr class="stat-table-header">
-            <td>Link events</td>
-          </tr>
-          <tr>
-            <td>Total added:</td>
-            <td style="text-align: right;">{{ total_added }}</td>
-          </tr>
-          <tr>
-            <td>Total removed:</td>
-            <td style="text-align: right;">{{ total_removed }}</td>
-          </tr>
-          <tr style="line-height:55px;">
-            <td></td>
-            <td style="text-align: right; font-weight: bold;
-                {% if total_diff > 0 %}
-                        color: green;">+
-                {% else %}
-                        color: red;">
-                {% endif %}
-                {{ total_diff }}
-            </td>
-          </tr>
-          <tr class="stat-table-header">
-            <td>Other</td>
-          </tr>
-          <tr>
-            <td>Total editors:</td>
-            <td style="text-align: right;">{{ total_editors }}</td>
-          </tr>
-          <tr>
-            <td>Total projects:</td>
-            <td style="text-align: right;">{{ total_projects }}</td>
-          </tr>
-      </table>
+      {% include "common/statistics_table.html" %}
     </div>
   </div>
   <div class="row" style="margin-top:40px;">
@@ -51,64 +16,19 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <table class="table">
-        <tr>
-          <th>Organisation</th>
-          <th>Net Change</th>
-        </tr>
-        {% for organisation in top_organisations %}
-          <tr>
-            <td>
-              <a href="{% url 'organisations:detail' pk=organisation.organisation__pk %}?{{ query_string }}">{{ organisation.organisation__name|truncatechars:20 }}</a>
-            </td>
-            <td>
-              {{ organisation.links_diff }}
-            </td>
-          </tr>
-        {% endfor %}
-      </table>
+      {% include "common/top_organisations_table.html" %}
       <div style="text-align:right;">
         <a href="{% url 'programs:csv_org_totals' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
       </div>
     </div>
     <div class="col-4">
-        <table class="table">
-            <tr>
-              <th>Project</th>
-              <th>Net Change</th>
-            </tr>
-            {% for project in top_projects %}
-              <tr>
-                <td>
-                  {{ project.project_name }}
-                </td>
-                <td>
-                  {{ project.links_diff }}
-                </td>
-              </tr>
-            {% endfor %}
-        </table>
+        {% include "common/top_projects_table.html" %}
         <div style="text-align:right;">
             <a href="{% url 'programs:csv_project_totals' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
         </div>
     </div>
     <div class="col-4">
-      <table class="table">
-          <tr>
-            <th>Username</th>
-            <th>Net Change</th>
-          </tr>
-          {% for user in top_users %}
-            <tr>
-              <td>
-                <a href="https://meta.wikimedia.org/wiki/User:{{ user.username }}">{{ user.username|truncatechars:15 }}</a>
-              </td>
-              <td>
-                {{ user.links_diff }}
-              </td>
-            </tr>
-          {% endfor %}
-      </table>
+      {% include "common/top_users_table.html" %}
       <div style="text-align:right;">
         <a href="{% url 'programs:csv_user_totals' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
       </div>

--- a/extlinks/programs/templates/programs/program_charts_include.html
+++ b/extlinks/programs/templates/programs/program_charts_include.html
@@ -54,20 +54,12 @@
       <table class="table">
         <tr>
           <th>Organisation</th>
-          <th>Added</th>
-          <th>Removed</th>
           <th>Net Change</th>
         </tr>
         {% for organisation in top_organisations %}
           <tr>
             <td>
               <a href="{% url 'organisations:detail' pk=organisation.organisation__pk %}?{{ query_string }}">{{ organisation.organisation__name|truncatechars:20 }}</a>
-            </td>
-            <td>
-              {{ organisation.links_added }}
-            </td>
-            <td>
-              {{ organisation.links_removed }}
             </td>
             <td>
               {{ organisation.links_diff }}
@@ -83,20 +75,12 @@
         <table class="table">
             <tr>
               <th>Project</th>
-              <th>Added</th>
-              <th>Removed</th>
               <th>Net Change</th>
             </tr>
             {% for project in top_projects %}
               <tr>
                 <td>
                   {{ project.project_name }}
-                </td>
-                <td>
-                  {{ project.links_added }}
-                </td>
-                <td>
-                  {{ project.links_removed }}
                 </td>
                 <td>
                   {{ project.links_diff }}
@@ -112,20 +96,12 @@
       <table class="table">
           <tr>
             <th>Username</th>
-            <th>Added</th>
-            <th>Removed</th>
             <th>Net Change</th>
           </tr>
           {% for user in top_users %}
             <tr>
               <td>
                 <a href="https://meta.wikimedia.org/wiki/User:{{ user.username }}">{{ user.username|truncatechars:15 }}</a>
-              </td>
-              <td>
-                {{ user.links_added }}
-              </td>
-              <td>
-                {{ user.links_removed }}
               </td>
               <td>
                 {{ user.links_diff }}

--- a/extlinks/programs/views.py
+++ b/extlinks/programs/views.py
@@ -214,33 +214,27 @@ class ProgramDetailView(DetailView):
             LinkAggregate.objects.filter(queryset_filter)
             .values("organisation__pk", "organisation__name")
             .annotate(
-                links_added=Sum("total_links_added"),
-                links_removed=Sum("total_links_removed"),
                 links_diff=Sum("total_links_added") - Sum("total_links_removed"),
             )
-            .order_by("-links_diff", "-links_added", "-links_removed")
+            .order_by("-links_diff")
         )[:5]
 
         context["top_projects"] = (
             PageProjectAggregate.objects.filter(queryset_filter)
             .values("project_name")
             .annotate(
-                links_added=Sum("total_links_added"),
-                links_removed=Sum("total_links_removed"),
                 links_diff=Sum("total_links_added") - Sum("total_links_removed"),
             )
-            .order_by("-links_diff", "-links_added", "-links_removed")
+            .order_by("-links_diff")
         )[:5]
 
         context["top_users"] = (
             UserAggregate.objects.filter(queryset_filter)
             .values("username")
             .annotate(
-                links_added=Sum("total_links_added"),
-                links_removed=Sum("total_links_removed"),
                 links_diff=Sum("total_links_added") - Sum("total_links_removed"),
             )
-            .order_by("-links_diff", "-links_added", "-links_removed")
+            .order_by("-links_diff")
         )[:5]
 
         return context

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -15,6 +15,8 @@ hr {
 
 .charts-body {
     padding: 2%;
+    width: 100%;
+
 }
 
 .navbar {


### PR DESCRIPTION
## Description
After merging #55, we noticed that the Totals tables bump into each other because of the extra column added. This happened on certain screen sizes.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This PR removes the `Links Added` and `Links Removed` columns from the `Totals` tables. Note that these columns will still appear when a  user wants to download a CSV file with the relevant information. 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T270335](https://phabricator.wikimedia.org/T270335)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
This was tested manually, on screens of different sizes.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before**
<img width="1139" alt="Screen Shot 2020-12-16 at 21 39 23" src="https://user-images.githubusercontent.com/7854953/102441091-3559b980-3fe7-11eb-8e94-c392a27358a9.png">


**After**
<img width="1106" alt="Screen Shot 2020-12-16 at 21 40 30" src="https://user-images.githubusercontent.com/7854953/102441151-59b59600-3fe7-11eb-971a-16eae727708f.png">


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
