### PR TITLE
Bug fix: DoesNotExistError

### DIFF
--- a/extlinks/aggregates/management/commands/fill_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_link_aggregates.py
@@ -1,6 +1,6 @@
 from datetime import date, timedelta, datetime
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.core.exceptions import ValidationError
 from django.db.models import Count, Q, Prefetch
 from django.db.models.functions import Cast
@@ -14,13 +14,58 @@ from extlinks.organisations.models import Collection
 class Command(BaseCommand):
     help = "Adds aggregated data into the LinkAggregate table"
 
+    def add_arguments(self, parser):
+        # Named (optional) arguments
+        parser.add_argument(
+            "--collections",
+            nargs="+",
+            type=int,
+            help="A list of collection IDs that will be processed instead of every collection",
+        )
+
     def handle(self, *args, **options):
+        if options["collections"]:
+            for col_id in options["collections"]:
+                try:
+                    collection = Collection.objects.get(pk=col_id)
+                except Collection.DoesNotExist:
+                    raise CommandError(f"Collection '{col_id}' does not exist")
+
+                link_event_filter = self._get_linkevent_filter(collection)
+                self._process_single_collection(link_event_filter, collection)
+        else:
+            # Looping through all collections
+            link_event_filter = self._get_linkevent_filter()
+            collections = Collection.objects.all().prefetch_related("url")
+
+            for collection in collections:
+                self._process_single_collection(link_event_filter, collection)
+
+    def _get_linkevent_filter(self, collection=None):
+        """
+        This function checks if there is information in the LinkAggregate table
+        to see what filters it should apply to the link events further on in the
+        process
+
+        Parameters
+        ----------
+        collection : Collection|None
+            A collection to filter the LinkAggregate table. Is None by default
+
+        Returns
+        -------
+        Q object
+        """
         today = date.today()
         last_day_of_last_month = today.replace(day=1) - timedelta(days=1)
         yesterday = today - timedelta(days=1)
 
-        # Check if the LinkAggregate table is empty
-        if LinkAggregate.objects.exists():
+        if collection:
+            linkaggregate_filter = Q(collection=collection)
+        else:
+            linkaggregate_filter = Q()
+
+        if LinkAggregate.objects.filter(linkaggregate_filter).exists():
             latest_aggregated_link_date = LinkAggregate.objects.latest("full_date")
             latest_datetime = datetime(
                 latest_aggregated_link_date.full_date.year,
@@ -38,12 +83,12 @@ class Command(BaseCommand):
             # There are no link aggregates, getting all LinkEvents from yesterday and backwards
             link_event_filter = Q(timestamp__lte=yesterday)
 
-        self._process_collections(link_event_filter)
+        return link_event_filter
 
-    def _process_collections(self, link_event_filter):
+    def _process_single_collection(self, link_event_filter, collection):
         """
-        This function loops through all collections to check on new link events
-        filtered by the dates passed in link_event_filter
+        This function loops through all url patterns in a collection to check on
+        new link events filtered by the dates passed in link_event_filter
 
         Parameters
         ----------
@@ -52,33 +97,33 @@ class Command(BaseCommand):
             is empty, it will query all LinkEvents. If it has data, it will query
             by the latest date in the table and today
 
+        collection: Collection
+            A specific collection to fetch all link events
+
         Returns
         -------
         None
         """
-        collections = Collection.objects.all().prefetch_related("url")
-
-        for collection in collections:
-            url_patterns = collection.url.all()
-            for url_pattern in url_patterns:
-                link_events_with_annotated_timestamp = url_pattern.linkevent.annotate(
-                    timestamp_date=Cast("timestamp", DateField())
+        url_patterns = collection.url.all()
+        for url_pattern in url_patterns:
+            link_events_with_annotated_timestamp = url_pattern.linkevent.annotate(
+                timestamp_date=Cast("timestamp", DateField())
+            )
+            link_events = (
+                link_events_with_annotated_timestamp.values("timestamp_date")
+                .filter(link_event_filter)
+                .annotate(
+                    links_added=Count(
+                        "pk",
+                        filter=Q(change=LinkEvent.ADDED),
+                        distinct=True,
+                    ),
+                    links_removed=Count(
+                        "pk", filter=Q(change=LinkEvent.REMOVED), distinct=True
+                    ),
                 )
-                link_events = (
-                    link_events_with_annotated_timestamp.values("timestamp_date")
-                    .filter(link_event_filter)
-                    .annotate(
-                        links_added=Count(
-                            "pk",
-                            filter=Q(change=LinkEvent.ADDED),
-                            distinct=True,
-                        ),
-                        links_removed=Count(
-                            "pk", filter=Q(change=LinkEvent.REMOVED), distinct=True
-                        ),
-                    )
-                )
-                self._fill_link_aggregates(link_events, collection)
+            )
+            self._fill_link_aggregates(link_events, collection)
 
     def _fill_link_aggregates(self, link_events, collection):
         """

--- a/extlinks/aggregates/management/commands/fill_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_user_aggregates.py
@@ -1,6 +1,6 @@
 from datetime import date, timedelta, datetime
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.core.exceptions import ValidationError
 from django.db.models import Count, Q, Prefetch
 from django.db.models.functions import Cast
@@ -14,13 +14,58 @@ from extlinks.organisations.models import Collection
 class Command(BaseCommand):
     help = "Adds aggregated data into the UserAggregate table"
 
+    def add_arguments(self, parser):
+        # Named (optional) arguments
+        parser.add_argument(
+            "--collections",
+            nargs="+",
+            type=int,
+            help="A list of collection IDs that will be processed instead of every collection",
+        )
+
     def handle(self, *args, **options):
+        if options["collections"]:
+            for col_id in options["collections"]:
+                try:
+                    collection = Collection.objects.get(pk=col_id)
+                except Collection.DoesNotExist:
+                    raise CommandError(f"Collection '{col_id}' does not exist")
+
+                link_event_filter = self._get_linkevent_filter(collection)
+                self._process_single_collection(link_event_filter, collection)
+        else:
+            # Looping through all collections
+            link_event_filter = self._get_linkevent_filter()
+            collections = Collection.objects.all().prefetch_related("url")
+
+            for collection in collections:
+                self._process_single_collection(link_event_filter, collection)
+
+    def _get_linkevent_filter(self, collection=None):
+        """
+        This function checks if there is information in the UserAggregate table
+        to see what filters it should apply to the link events further on in the
+        process
+
+        Parameters
+        ----------
+        collection : Collection|None
+            A collection to filter the UserAggregate table. Is None by default
+
+        Returns
+        -------
+        Q object
+        """
         today = date.today()
         last_day_of_last_month = today.replace(day=1) - timedelta(days=1)
         yesterday = today - timedelta(days=1)
 
-        # Check if the UserAggregate table is empty
-        if UserAggregate.objects.exists():
+        if collection:
+            linkaggregate_filter = Q(collection=collection)
+        else:
+            linkaggregate_filter = Q()
+
+        if UserAggregate.objects.filter(linkaggregate_filter).exists():
             latest_aggregated_link_date = UserAggregate.objects.latest("full_date")
             latest_datetime = datetime(
                 latest_aggregated_link_date.full_date.year,
@@ -35,15 +80,15 @@ class Command(BaseCommand):
                 timestamp__gte=latest_datetime,
             )
         else:
-            # There are no page aggregates, getting all LinkEvents from yesterday and backwards
+            # There are no link aggregates, getting all LinkEvents from yesterday and backwards
             link_event_filter = Q(timestamp__lte=yesterday)
 
-        self._process_collections(link_event_filter)
+        return link_event_filter
 
-    def _process_collections(self, link_event_filter):
+    def _process_single_collection(self, link_event_filter, collection):
         """
-        This function loops through all collections to check on new link events
-        filtered by the dates passed in link_event_filter
+        This function loops through all url patterns in a collection to check on
+        new link events filtered by the dates passed in link_event_filter
 
         Parameters
         ----------
@@ -52,35 +97,35 @@ class Command(BaseCommand):
             is empty, it will query all LinkEvents. If it has data, it will query
             by the latest date in the table and today
 
+        collection: Collection
+            A specific collection to fetch all link events
+
         Returns
         -------
         None
         """
-        collections = Collection.objects.all().prefetch_related("url")
-
-        for collection in collections:
-            url_patterns = collection.url.all()
-            for url_pattern in url_patterns:
-                link_events_with_annotated_timestamp = url_pattern.linkevent.annotate(
-                    timestamp_date=Cast("timestamp", DateField())
+        url_patterns = collection.url.all()
+        for url_pattern in url_patterns:
+            link_events_with_annotated_timestamp = url_pattern.linkevent.annotate(
+                timestamp_date=Cast("timestamp", DateField())
+            )
+            link_events = (
+                link_events_with_annotated_timestamp.values(
+                    "username__username", "timestamp_date"
                 )
-                link_events = (
-                    link_events_with_annotated_timestamp.values(
-                        "username__username", "timestamp_date"
-                    )
-                    .filter(link_event_filter)
-                    .annotate(
-                        links_added=Count(
-                            "pk",
-                            filter=Q(change=LinkEvent.ADDED),
-                            distinct=True,
-                        ),
-                        links_removed=Count(
-                            "pk", filter=Q(change=LinkEvent.REMOVED), distinct=True
-                        ),
-                    )
+                .filter(link_event_filter)
+                .annotate(
+                    links_added=Count(
+                        "pk",
+                        filter=Q(change=LinkEvent.ADDED),
+                        distinct=True,
+                    ),
+                    links_removed=Count(
+                        "pk", filter=Q(change=LinkEvent.REMOVED), distinct=True
+                    ),
                 )
-                self._fill_user_aggregates(link_events, collection)
+            )
+            self._fill_user_aggregates(link_events, collection)
 
     def _fill_user_aggregates(self, link_events, collection):
         """

--- a/extlinks/aggregates/tests.py
+++ b/extlinks/aggregates/tests.py
@@ -287,15 +287,56 @@ class UserAggregateCommandTest(TestCase):
         call_command("fill_user_aggregates")
 
         # Now, the link aggregate should have 2 event links added in
-        updated_page_aggregate = UserAggregate.objects.get(
+        updated_user_aggregate = UserAggregate.objects.get(
             organisation=self.organisation,
             collection=self.collection,
             username=self.user,
             full_date=yesterday.date(),
         )
 
-        self.assertEqual(updated_page_aggregate.total_links_added, 2)
-        self.assertEqual(updated_page_aggregate.total_links_removed, 0)
+        self.assertEqual(updated_user_aggregate.total_links_added, 2)
+        self.assertEqual(updated_user_aggregate.total_links_removed, 0)
+
+    def test_user_aggregate_with_argument(self):
+        # Create a new collection and some LinkEvents associated with it
+        new_collection = CollectionFactory(name="Monsters Inc")
+        url_pattern = URLPatternFactory(
+            url="www.duckduckgo.com", collection=new_collection
+        )
+        # Creating a collection and LinkEvent that won't be run in the command
+        other_collection = CollectionFactory(name="Unused")
+        other_url_pattern = URLPatternFactory(
+            url="www.notusingthis.com", collection=other_collection
+        )
+
+        new_link_event_1 = LinkEventFactory(timestamp=datetime(2020, 1, 1, 15, 30, 35))
+        new_link_event_1.url.add(url_pattern)
+        new_link_event_1.save()
+
+        new_link_event_2 = LinkEventFactory(timestamp=datetime(2020, 4, 23, 8, 50, 13))
+        new_link_event_2.url.add(url_pattern)
+        new_link_event_2.save()
+
+        other_link_event = LinkEventFactory()
+        other_link_event.url.add(other_url_pattern)
+        other_link_event.save()
+
+        self.assertEqual(
+            UserAggregate.objects.filter(collection=new_collection).count(),
+            0,
+        )
+
+        call_command("fill_user_aggregates", collections=[new_collection.pk])
+
+        self.assertEqual(
+            UserAggregate.objects.filter(collection=new_collection).count(),
+            2,
+        )
+
+    def test_user_aggregate_with_argument_error(self):
+        # Calling the command with a collection that doesn't exist
+        with self.assertRaises(CommandError):
+            call_command("fill_user_aggregates", collections=[9999999])
 
 
 class PageProjectAggregateCommandTest(TestCase):

--- a/extlinks/aggregates/tests.py
+++ b/extlinks/aggregates/tests.py
@@ -1,7 +1,7 @@
 import factory
 from datetime import datetime, date, timedelta
 
-from django.core.management import call_command
+from django.core.management import call_command, CommandError
 from django.test import TestCase
 
 from .factories import (
@@ -128,6 +128,36 @@ class LinkAggregateCommandTest(TestCase):
 
         self.assertEqual(updated_link_aggregate.total_links_added, 2)
         self.assertEqual(updated_link_aggregate.total_links_removed, 0)
+
+    def test_link_aggregate_with_argument(self):
+        # Create a new collection and some LinkEvents associated with it
+        new_collection = CollectionFactory(name="Monsters Inc")
+        url_pattern = URLPatternFactory(
+            url="www.duckduckgo.com", collection=new_collection
+        )
+
+        new_link_event_1 = LinkEventFactory(timestamp=datetime(2020, 1, 1, 15, 30, 35))
+        new_link_event_1.url.add(url_pattern)
+        new_link_event_1.save()
+
+        new_link_event_2 = LinkEventFactory(timestamp=datetime(2020, 4, 23, 8, 50, 13))
+        new_link_event_2.url.add(url_pattern)
+        new_link_event_2.save()
+
+        self.assertEqual(
+            LinkAggregate.objects.filter(collection=new_collection).count(), 0
+        )
+
+        call_command("fill_link_aggregates", collections=[new_collection.pk])
+
+        self.assertEqual(
+            LinkAggregate.objects.filter(collection=new_collection).count(), 2
+        )
+
+    def test_link_aggregate_with_argument_error(self):
+        # Calling the command with a collection that doesn't exist
+        with self.assertRaises(CommandError):
+            call_command("fill_link_aggregates", collections=[9999999])
 
 
 class UserAggregateCommandTest(TestCase):

--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -173,18 +173,15 @@ class OrganisationDetailView(DetailView):
         -------
         dict : The context dictionary with the relevant statistics
         """
-        try:
-            earliest_link_date = (
-                LinkAggregate.objects.filter(queryset_filter)
-                .earliest("full_date")
-                .full_date
-            )
-        except LinkAggregate.DoesNotExist:
-            earliest_link_date = (
-                LinkAggregate.objects.filter(collection=collection)
-                .earliest("full_date")
-                .full_date
-            )
+
+        filtered_link_aggregate = LinkAggregate.objects.filter(queryset_filter)
+
+        if filtered_link_aggregate:
+            earliest_link_date = filtered_link_aggregate.earliest("full_date").full_date
+        else:
+            # No link information from that collection, so setting earliest_link_date
+            # to January 1 2000, an arbitrary early date
+            earliest_link_date = datetime(2000, 1, 1)
 
         links_aggregated_date = (
             LinkAggregate.objects.filter(


### PR DESCRIPTION
## Description
A `DoesNotExist` error appears when a collection does not have information on the `LinkAggregate` table. Upon further inspection, the collection that has that error should have information. To fix this before this PR, we would have to clear the `LinkAggregate` table and run the `fill_link_aggregates` command again. Instead of doing that, we can now run the command so that it fills data for certain collections that weren't filled properly.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This will help fix any counting errors in certain collections without having to clear all of the information in an aggregate table.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T270427](https://phabricator.wikimedia.org/T270427)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tests have been added and it has been tested manually.

1. Go to the Django admin and delete the information from a collection on an aggregate table
2. Run the management command with the collections argument. Example `docker-compose exec externallinks python manage.py fill_link_aggregates --collections 24` where 24 is a collection id
3. Check that the collection has information in the aggregate table

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
