### PR TITLE
Add migration to fix Proquest Open URL linkevents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ __pycache__/
 
 static/admin
 static/debug_toolbar
+static/django_extensions
 
 db.json

--- a/extlinks/aggregates/management/commands/fill_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_link_aggregates.py
@@ -30,6 +30,9 @@ class Command(BaseCommand):
                     collection = Collection.objects.get(pk=col_id)
                 except Collection.DoesNotExist:
                     raise CommandError(f"Collection '{col_id}' does not exist")
+                    self.stdout.write(
+                        self.style.ERROR(f"Error: Collection '{col_id}' does not exist")
+                    )
 
                 link_event_filter = self._get_linkevent_filter(collection)
                 self._process_single_collection(link_event_filter, collection)
@@ -66,7 +69,9 @@ class Command(BaseCommand):
             linkaggregate_filter = Q()
 
         if LinkAggregate.objects.filter(linkaggregate_filter).exists():
-            latest_aggregated_link_date = LinkAggregate.objects.latest("full_date")
+            latest_aggregated_link_date = LinkAggregate.objects.filter(
+                linkaggregate_filter
+            ).latest("full_date")
             latest_datetime = datetime(
                 latest_aggregated_link_date.full_date.year,
                 latest_aggregated_link_date.full_date.month,

--- a/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
@@ -66,9 +66,9 @@ class Command(BaseCommand):
             linkaggregate_filter = Q()
 
         if PageProjectAggregate.objects.filter(linkaggregate_filter).exists():
-            latest_aggregated_link_date = PageProjectAggregate.objects.latest(
-                "full_date"
-            )
+            latest_aggregated_link_date = PageProjectAggregate.objects.filter(
+                linkaggregate_filter
+            ).latest("full_date")
             latest_datetime = datetime(
                 latest_aggregated_link_date.full_date.year,
                 latest_aggregated_link_date.full_date.month,

--- a/extlinks/aggregates/management/commands/fill_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_user_aggregates.py
@@ -66,7 +66,9 @@ class Command(BaseCommand):
             linkaggregate_filter = Q()
 
         if UserAggregate.objects.filter(linkaggregate_filter).exists():
-            latest_aggregated_link_date = UserAggregate.objects.latest("full_date")
+            latest_aggregated_link_date = UserAggregate.objects.filter(
+                linkaggregate_filter
+            ).latest("full_date")
             latest_datetime = datetime(
                 latest_aggregated_link_date.full_date.year,
                 latest_aggregated_link_date.full_date.month,

--- a/extlinks/links/migrations/0008_fill_proquest_openurl.py
+++ b/extlinks/links/migrations/0008_fill_proquest_openurl.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def add_link_events_to_proquest_openurl_collection(apps, schema_editor):
+    LinkEvent = apps.get_model("links", "LinkEvent")
+    Collection = apps.get_model("organisations", "Collection")
+    URLPattern = apps.get_model("links", "URLPattern")
+    proquest_openurl_collection = Collection.objects.filter(name="Proquest OpenURL")
+    if proquest_openurl_collection:
+        proquest_openurl_linkevents = LinkEvent.objects.filter(
+            link__icontains="gateway.proquest.com/openurl"
+        )
+        for proquest_openurl_linkevent in proquest_openurl_linkevents:
+            proquest_openurl_linkevent.url.add(proquest_openurl_collection.url.get())
+            proquest_openurl_linkevent.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("links", "0007_auto_20190730_1355")]
+
+    operations = [migrations.RunPython(add_link_events_to_proquest_openurl_collection)]


### PR DESCRIPTION
## Description
The `Proquest Open URL` collection was showing no data in the organization detail view. This was due to the fact that no link events were added to the URLPattern that is related to that collection. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
By adding a migration to fix this, the aggregate management commands can be run so that that collection has information.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Manually tested the migration and ran the aggregates commands for that collection.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
![Screen Shot 2020-12-22 at 18 37 20](https://user-images.githubusercontent.com/7854953/102945935-c7990c00-4484-11eb-8223-1e2d5f1da965.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
