### PR TITLE
Fix user list filter in organisation linkevents

### DIFF
--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -112,6 +112,8 @@ def build_queryset_filters(form_data, collection_or_organisations):
         collection_or_organisation_filter = Q(
             organisation__in=collection_or_organisations["organisations"]
         )
+    elif "linkevents" in collection_or_organisations:
+        collection_or_organisation_filter = Q()
     else:
         collection_or_organisation_filter = Q(
             collection=collection_or_organisations["collection"]
@@ -120,12 +122,18 @@ def build_queryset_filters(form_data, collection_or_organisations):
     if "start_date" in form_data:
         start_date = form_data["start_date"]
         if start_date:
-            start_date_filter = Q(full_date__gte=start_date)
+            if "linkevents" in collection_or_organisations:
+                start_date_filter = Q(timestamp__gte=start_date)
+            else:
+                start_date_filter = Q(full_date__gte=start_date)
     if "end_date" in form_data:
         end_date = form_data["end_date"]
         # The end date must not be greater than today's date
         if end_date:
-            end_date_filter = Q(full_date__lte=end_date)
+            if "linkevents" in collection_or_organisations:
+                end_date_filter = Q(timestamp__gte=end_date)
+            else:
+                end_date_filter = Q(full_date__lte=end_date)
 
     if "limit_to_user_list" in form_data:
         limit_to_user_list = form_data["limit_to_user_list"]

--- a/extlinks/common/views.py
+++ b/extlinks/common/views.py
@@ -174,14 +174,16 @@ class CSVUserTotals(_CSVDownloadView):
 class CSVAllLinkEvents(_CSVDownloadView):
     def _write_data(self, response):
         pk = self.kwargs["pk"]
+        queryset_filter = build_queryset_filters(self.request.GET, {"linkevents": ""})
         # If we came from an organisation page:
         if "/organisation" in self.request.build_absolute_uri():
             linkevents = LinkEvent.objects.filter(
-                url__collection__organisation__pk=pk
+                Q(url__collection__organisation__pk=pk) & queryset_filter
             ).distinct()
         else:
             program = Program.objects.get(pk=pk)
             linkevents = program.get_linkevents()
+            linkevents = linkevents.filter(queryset_filter)
 
         writer = csv.writer(response)
 


### PR DESCRIPTION
## Description
This PR fixes a bug where the Link Events list wasn't being filtered correctly in the organization detail view.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
When 'Limit to user list' is selected, the table of the latest link events should also be updated to only show the latest events from users on the user list.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T271414](https://phabricator.wikimedia.org/T271414)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Go to a random organization
2. Filter it by checking `Limit to user list`
3. See that the results are being filtered

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**With no filter**
![Screen Shot 2021-01-07 at 16 03 09](https://user-images.githubusercontent.com/7854953/103950688-ef35d880-5102-11eb-92d4-d6519b3c2afb.png)


**With `Limit to user list` filter**
![Screen Shot 2021-01-07 at 16 03 24](https://user-images.githubusercontent.com/7854953/103950714-fbba3100-5102-11eb-9dbd-4899f9e2e5fb.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
