### PR TITLE
Add order by clause in LinkAggregate chart query

### DIFF
--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -191,12 +191,16 @@ class OrganisationDetailView(DetailView):
             .annotate(
                 net_change=Sum("total_links_added") - Sum("total_links_removed"),
             )
+            .order_by("year", "month")
         )
 
         eventstream_dates = []
         eventstream_net_change = []
         for link in links_aggregated_date:
-            date_combined = f"{link['year']}-{link['month']}"
+            if link["month"] < 10:
+                date_combined = f"{link['year']}-0{link['month']}"
+            else:
+                date_combined = f"{link['year']}-{link['month']}"
             eventstream_dates.append(date_combined)
             eventstream_net_change.append(link["net_change"])
 


### PR DESCRIPTION
## Description
Added an `order_by` clause in a LinkAggregate query.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Sometimes, the dates would present themselves out of order. By adding the `order_by` clause, we can force the query to consistently return data in the desired order.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T271408](https://phabricator.wikimedia.org/T271408)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
I have not been able to reproduce this error locally

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
