### PR TITLE
Store wikilink backups on nfs share

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
    command: ["/app/bin/gunicorn.sh"]
    volumes:
      - ./:/app
+     - type: bind
+       source: ${HOST_BACKUP_DIR}
+       target: /app/backup
  db:
    image: quay.io/wikipedialibrary/mysql:5.7
    env_file:

--- a/template.env
+++ b/template.env
@@ -13,3 +13,5 @@ TWL_API_TOKEN=token
 # When pulling, these define which images are pulled
 EVENTSTREAM_TAG=latest
 EXTERNALLINKS_TAG=latest
+# Change to something like /data/project/prod for real servers.
+HOST_BACKUP_DIR=./backup


### PR DESCRIPTION
## Description
We previously established automated backups (T254327), but since we were waiting on a project NFS share, they were stored on the local filesystem. Now that we have that NFS share (T264107), we need to update the puppet config to enable access for the production instance and add an appropriate bind mount to our docker compose, just like we've done in TWLight.

## Rationale
This improves our backup durability and abillity to recover from oopsies.

## Phabricator Ticket
https://phabricator.wikimedia.org/T271110

## How Has This Been Tested?
I tested the new default mount (same location as the old implicit one) locally. There's not much of a way to test this other than to get it deployed, but we're doing exactly the same thing in TWLight.

## Screenshots of your changes (if appropriate):
NA

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
