### PR TITLE
Add 0 if there is no data in month when filling charts

### DIFF
--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date, timedelta
 import re
 
 from django.db.models import Count, Sum, Q
@@ -173,7 +173,11 @@ class OrganisationDetailView(DetailView):
         -------
         dict : The context dictionary with the relevant statistics
         """
-
+        dates = []
+        existing_link_aggregates = {}
+        eventstream_dates = []
+        eventstream_net_change = []
+        current_date = date.today()
         filtered_link_aggregate = LinkAggregate.objects.filter(queryset_filter)
 
         if filtered_link_aggregate:
@@ -194,15 +198,28 @@ class OrganisationDetailView(DetailView):
             .order_by("year", "month")
         )
 
-        eventstream_dates = []
-        eventstream_net_change = []
+        # Filling an array of dates that should be in the chart
+        while current_date >= earliest_link_date:
+            dates.append(current_date.strftime("%Y-%m"))
+            # Figure out what the last month is regardless of today's date
+            current_date = current_date.replace(day=1) - timedelta(days=1)
+
+        dates = dates[::-1]
+
         for link in links_aggregated_date:
             if link["month"] < 10:
                 date_combined = f"{link['year']}-0{link['month']}"
             else:
                 date_combined = f"{link['year']}-{link['month']}"
-            eventstream_dates.append(date_combined)
-            eventstream_net_change.append(link["net_change"])
+
+            existing_link_aggregates[date_combined] = link["net_change"]
+
+        for month_year in dates:
+            eventstream_dates.append(month_year)
+            if month_year in existing_link_aggregates:
+                eventstream_net_change.append(existing_link_aggregates[month_year])
+            else:
+                eventstream_net_change.append(0)
 
         # These stats are for filling the program net change chart
         context["eventstream_dates"] = eventstream_dates


### PR DESCRIPTION
## Description
When there was no information for a month, the graph was not displaying that month (not even a zero). This PR fixes this bug.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Even if there is a 0 data point for a month, we should show that and not skip the month, for clarity.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T271409](https://phabricator.wikimedia.org/T271409)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
1. Go to a program or organization
2. Select the `Limit to user list` filter
3. Verify that every month is still displayed (even with a zero)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before**
Only two months are being displayed because there is only data for those specific months
![Screen Shot 2021-01-14 at 19 28 11](https://user-images.githubusercontent.com/7854953/104669248-502f5480-569f-11eb-80b1-2afa5354547a.png)


**After**
Data is shown for every month, giving the chart more clarity
![Screen Shot 2021-01-14 at 19 28 02](https://user-images.githubusercontent.com/7854953/104669301-69380580-569f-11eb-8b24-c9841960fe10.png)



## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
