### PR TITLE
Fix date comparison error

### DIFF
--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -131,7 +131,7 @@ def build_queryset_filters(form_data, collection_or_organisations):
         # The end date must not be greater than today's date
         if end_date:
             if "linkevents" in collection_or_organisations:
-                end_date_filter = Q(timestamp__gte=end_date)
+                end_date_filter = Q(timestamp__lte=end_date)
             else:
                 end_date_filter = Q(full_date__lte=end_date)
 

--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -184,13 +184,11 @@ class OrganisationDetailView(DetailView):
             earliest_link_date = filtered_link_aggregate.earliest("full_date").full_date
         else:
             # No link information from that collection, so setting earliest_link_date
-            # to January 1 2000, an arbitrary early date
-            earliest_link_date = datetime(2000, 1, 1)
+            # to the first of the current month
+            earliest_link_date = current_date.replace(day=1)
 
         links_aggregated_date = (
-            LinkAggregate.objects.filter(
-                queryset_filter & Q(full_date__gte=earliest_link_date),
-            )
+            LinkAggregate.objects.filter(queryset_filter)
             .values("month", "year")
             .annotate(
                 net_change=Sum("total_links_added") - Sum("total_links_removed"),

--- a/extlinks/programs/views.py
+++ b/extlinks/programs/views.py
@@ -126,13 +126,11 @@ class ProgramDetailView(DetailView):
             earliest_link_date = filtered_link_aggregate.earliest("full_date").full_date
         else:
             # No link information from that collection, so setting earliest_link_date
-            # to January 1 2000, an arbitrary early date
-            earliest_link_date = datetime(2000, 1, 1)
+            # to the first of the current month
+            earliest_link_date = current_date.replace(day=1)
 
         links_aggregated_date = (
-            LinkAggregate.objects.filter(
-                queryset_filter & Q(full_date__gte=earliest_link_date),
-            )
+            LinkAggregate.objects.filter(queryset_filter)
             .values("month", "year")
             .annotate(
                 net_change=Sum("total_links_added") - Sum("total_links_removed"),


### PR DESCRIPTION
## Description
There was an `Exception Value: can't compare datetime.datetime to datetime.date` when trying to get information from organizations or programs. 

There was also a minor bug in the building of the Q object to filter by `end_date`. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This solves bugs that impede functionality.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T272363](https://phabricator.wikimedia.org/T272363)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
