### PR TITLE
Track proxy urls

### DIFF
--- a/extlinks/links/management/commands/remove_ezproxy_collection.py
+++ b/extlinks/links/management/commands/remove_ezproxy_collection.py
@@ -1,0 +1,60 @@
+from django.core.management.base import BaseCommand, call_command
+
+from extlinks.aggregates.models import (
+    LinkAggregate,
+    PageProjectAggregate,
+    UserAggregate,
+)
+from extlinks.links.models import URLPattern, LinkEvent
+from extlinks.organisations.models import Organisation, Collection
+
+
+class Command(BaseCommand):
+    help = "Monitors page-links-change for link events"
+
+    def handle(self, *args, **options):
+        # Delete organisations, collections and URLPatterns that are related to
+        # EZProxy
+        ezproxy_org = Organisation.objects.filter(name="Wikipedia Library OCLC EZProxy")
+        ezproxy_collection = Collection.objects.filter(name="EZProxy")
+        url_patterns = URLPattern.objects.filter(collection=ezproxy_collection)
+
+        LinkAggregate.objects.filter(
+            organisation=ezproxy_org, collection=ezproxy_collection
+        ).delete()
+        PageProjectAggregate.objects.filter(
+            organisation=ezproxy_org, collection=ezproxy_collection
+        ).delete()
+        UserAggregate.objects.filter(
+            organisation=ezproxy_org, collection=ezproxy_collection
+        ).delete()
+
+        url_patterns.delete()
+        ezproxy_collection.delete()
+        ezproxy_org.delete()
+
+        # Get LinkEvents that have no URLPatterns associated
+        linkevents = LinkEvent.objects.filter(url__isnull=True)
+
+        collections = Collection.objects.all()
+
+        linkevents_changed = 0
+        for collection in collections:
+            collection_urls = collection.url.all()
+            for url_pattern in collection_urls:
+                for linkevent in linkevents:
+                    proxy_url = url_pattern.url.replace(".", "-")
+                    if url_pattern.url in linkevent.link or proxy_url in linkevent.link:
+                        linkevent.url.add(url_pattern)
+                        linkevents_changed += 1
+            if linkevents_changed > 0:
+                # There have been changes to this collection, so we must delete
+                # the aggregates tables for that collection and run the commands
+                # for it
+                LinkAggregate.objects.filter(collection=collection).delete()
+                PageProjectAggregate.objects.filter(collection=collection).delete()
+                UserAggregate.objects.filter(collection=collection).delete()
+
+                call_command("fill_link_aggregates", collections=[collection.pk])
+                call_command("fill_pageproject_aggregates", collections=[collection.pk])
+                call_command("fill_user_aggregates", collections=[collection.pk])

--- a/extlinks/links/management/commands/remove_ezproxy_collection.py
+++ b/extlinks/links/management/commands/remove_ezproxy_collection.py
@@ -11,14 +11,17 @@ from extlinks.organisations.models import Organisation, Collection
 
 
 class Command(BaseCommand):
-    help = "Monitors page-links-change for link events"
+    help = "Deletes the EZProxy collection and organisation and reassigns those LinkEvents to new URLPatterns"
 
     def handle(self, *args, **options):
         ezproxy_org = self._get_ezproxy_organisation()
         ezproxy_collection = self._get_ezproxy_collection()
         url_patterns = self._get_ezproxy_url_patterns(ezproxy_collection)
 
-        self._delete_aggregates_ezproxy(ezproxy_org, ezproxy_collection, url_patterns)
+        if ezproxy_org and ezproxy_collection and url_patterns:
+            self._delete_aggregates_ezproxy(
+                ezproxy_org, ezproxy_collection, url_patterns
+            )
 
         # Get LinkEvents that have no URLPatterns associated
         linkevents = LinkEvent.objects.filter(url__isnull=True)
@@ -28,24 +31,76 @@ class Command(BaseCommand):
         self._process_linkevents_collections(linkevents, collections)
 
     def _get_ezproxy_organisation(self):
+        """
+        Gets the EZProxy organisation, or returns None if it's already been deleted
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        Organisation object or None
+        """
         if Organisation.objects.filter(name="Wikipedia Library OCLC EZProxy").exists():
             return Organisation.objects.get(name="Wikipedia Library OCLC EZProxy")
 
         return None
 
     def _get_ezproxy_collection(self):
+        """
+        Gets the EZProxy collection, or returns None if it's already been deleted
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        Collection object or None
+        """
         if Collection.objects.filter(name="EZProxy").exists():
             return Collection.objects.get(name="EZProxy")
 
         return None
 
     def _get_ezproxy_url_patterns(self, collection):
+        """
+        Gets the EZProxy collection, or returns None if it's already been deleted
+
+        Parameters
+        ----------
+        collection: The collection the URLPatterns belong to
+
+        Returns
+        -------
+        URLPattern object or None
+        """
         if collection and URLPattern.objects.filter(collection=collection).exists():
             return URLPattern.objects.get(collection=collection)
 
         return None
 
     def _delete_aggregates_ezproxy(self, ezproxy_org, ezproxy_collection, url_patterns):
+        """
+        Deletes any aggregate with the EZProxy collection and organisation,
+        then deletes the collection, organisation and url patterns
+
+        Parameters
+        ----------
+        ezproxy_org: Organisation
+        The organisation to filter and delete the aggregates tables and that
+        will later be deleted
+
+        ezproxy_collection: Collection
+        The collection to filter and delete the aggregates tables and that
+        will later be deleted
+
+        url_patterns: URLPattern
+        The EZProxy URLPatterns that will be deleted
+
+        Returns
+        -------
+
+        """
         LinkAggregate.objects.filter(
             organisation=ezproxy_org, collection=ezproxy_collection
         ).delete()
@@ -61,6 +116,23 @@ class Command(BaseCommand):
         ezproxy_org.delete()
 
     def _process_linkevents_collections(self, linkevents, collections):
+        """
+        Loops through all collections to get their url patterns. If a linkevent
+        link coincides with a URLPattern, it is added to that LinkEvent. That way,
+        it will be counted when the aggregates commands are run again
+
+        Parameters
+        ----------
+        linkevents: Queryset[LinkEvent]
+        LinkEvent that have no URLPatterns assigned (therefore no collection assigned)
+
+        collections: Queryset[Collection]
+        All of the collections
+
+        Returns
+        -------
+
+        """
         linkevents_changed = 0
         for collection in collections:
             collection_urls = collection.url.all()

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from extlinks.organisations.factories import OrganisationFactory, CollectionFactory
 from .factories import LinkEventFactory, URLPatternFactory
 from .helpers import link_is_tracked, split_url_for_query
-from .models import URLPattern
+from .models import URLPattern, LinkEvent
 
 
 class LinksHelpersTest(TestCase):
@@ -144,3 +144,190 @@ class URLPatternModelTest(TestCase):
         """
         test_urlpattern = URLPattern(url="platform.almanhal.com")
         self.assertEqual(test_urlpattern.get_proxied_url, "platform-almanhal-com")
+
+
+class LinkEventsCollectCommandTest(TestCase):
+    def setUp(self):
+        self.organisation1 = OrganisationFactory(name="JSTOR")
+        self.collection1 = CollectionFactory(
+            name="JSTOR", organisation=self.organisation1
+        )
+        self.url = URLPatternFactory(url="www.jstor.org", collection=self.collection1)
+        self.event_data1 = {
+            "$schema": "/mediawiki/page/links-change/1.0.0",
+            "meta": {
+                "uri": "https://en.wikipedia.org/wiki/Tanya_Tuzova",
+                "request_id": "db830ce7-1aa8-4984-baa3-7598ea7113d2",
+                "id": "4100e9a8-af77-405f-ab13-ec0957a7c24c",
+                "dt": "2020-08-20T21:22:46Z",
+                "domain": "en.wikipedia.org",
+                "stream": "mediawiki.page-links-change",
+                "topic": "eqiad.mediawiki.page-links-change",
+                "partition": 0,
+                "offset": 840218818,
+            },
+            "database": "enwiki",
+            "page_id": 63608061,
+            "page_title": "Page1",
+            "page_namespace": 0,
+            "page_is_redirect": False,
+            "rev_id": 974060045,
+            "performer": {
+                "user_text": "User1",
+                "user_groups": ["extendedconfirmed", "*", "user", "autoconfirmed"],
+                "user_is_bot": False,
+                "user_id": 32001896,
+                "user_registration_dt": "2017-09-24T15:12:43Z",
+                "user_edit_count": 2099,
+            },
+            "removed_links": [
+                {
+                    "link": "/wiki/Wikipedia:Articles_for_deletion/Tanya_Tuzova",
+                    "external": False,
+                },
+                {"link": "/wiki/Wikipedia:Deletion_policy", "external": False},
+                {"link": "/wiki/Wikipedia:Guide_to_deletion", "external": False},
+                {"link": "/wiki/Wikipedia:Page_blanking", "external": False},
+                {
+                    "link": "//scholar.google.com/scholar%3Fq%3D%2522Tanya%2BTuzova%2522",
+                    "external": True,
+                },
+                {
+                    "link": "https://www.jstor.org/action/doBasicSearch%3FQuery%3D%2522Tanya%2BTuzova%2522%26acc%3Don%26wc%3Don",
+                    "external": True,
+                },
+            ],
+        }
+        self.event_data2 = {
+            "$schema": "/mediawiki/page/links-change/1.0.0",
+            "meta": {
+                "uri": "https://en.wikipedia.org/wiki/Tanya_Tuzova",
+                "request_id": "db830ce7-1aa8-4984-baa3-7598ea7113d2",
+                "id": "4100e9a8-af77-405f-ab13-ec0957a7c24c",
+                "dt": "2020-08-20T21:22:46Z",
+                "domain": "en.wikipedia.org",
+                "stream": "mediawiki.page-links-change",
+                "topic": "eqiad.mediawiki.page-links-change",
+                "partition": 0,
+                "offset": 840218818,
+            },
+            "database": "enwiki",
+            "page_id": 63608061,
+            "page_title": "Page1",
+            "page_namespace": 0,
+            "page_is_redirect": False,
+            "rev_id": 974060041,
+            "performer": {
+                "user_text": "User1",
+                "user_groups": ["extendedconfirmed", "*", "user", "autoconfirmed"],
+                "user_is_bot": False,
+                "user_id": 32001896,
+                "user_registration_dt": "2017-09-24T15:12:43Z",
+                "user_edit_count": 6550,
+            },
+            "added_links": [
+                {
+                    "link": "/wiki/Wikipedia:Articles_for_deletion/Tanya_Tuzova",
+                    "external": False,
+                },
+                {"link": "/wiki/Wikipedia:Deletion_policy", "external": False},
+                {"link": "/wiki/Wikipedia:Guide_to_deletion", "external": False},
+                {"link": "/wiki/Wikipedia:Page_blanking", "external": False},
+                {
+                    "link": "https://www-jstor-org.wikipedialibrary.idm.oclc.org/stable/27903775?Search=yes&resultItemClick=true&searchText=%22Evil+as+an+Explanatory+Concept%22&searchUri=/action/doBasicSearch?Query%3D%2522Evil%2Bas%2Ban%2BExplanatory%2BConcept%2522%26acc%3Don%26wc%3Don%26fc%3Doff%26group%3Dnone%26refreqid%3Dsearch%253Aad56779891b6147f11436f1629fe704d&ab_segments=0/basic_SYC-5187_SYC-5188/5188&refreqid=fastly-default:21cde56a64c1528014fba9e12d054b80&seq=1#metadata_info_tab_contents",
+                    "external": True,
+                },
+                {
+                    "link": "https://www-jstor-org.wikipedialibrary.idm.oclc.org/stable/dklsajdlkajslkdjaslkdjalks",
+                    "external": True,
+                },
+            ],
+        }
+
+    def test_management_command_non_proxy(self):
+        self.assertEqual(LinkEvent.objects.count(), 0)
+        with self.assertRaises(SystemExit):
+            call_command("linkevents_collect", test=self.event_data1)
+        self.assertEqual(LinkEvent.objects.count(), 1)
+
+    def test_management_command_proxy_urls(self):
+        self.assertEqual(LinkEvent.objects.count(), 0)
+        with self.assertRaises(SystemExit):
+            call_command("linkevents_collect", test=self.event_data2)
+        self.assertEqual(LinkEvent.objects.count(), 2)
+
+
+class EZProxyRemovalCommandTest(TestCase):
+    def setUp(self):
+        self.jstor_organisation = OrganisationFactory(name="JSTOR")
+        self.jstor_collection = CollectionFactory(
+            name="JSTOR", organisation=self.jstor_organisation
+        )
+        self.jstor_url_pattern = URLPatternFactory(
+            url="www.jstor.org", collection=self.jstor_collection
+        )
+
+        self.proquest_organisation = OrganisationFactory(name="ProQuest")
+        self.proquest_collection = CollectionFactory(
+            name="ProQuest", organisation=self.proquest_organisation
+        )
+        self.proquest_url_pattern = URLPatternFactory(
+            url="www.proquest.com", collection=self.proquest_collection
+        )
+
+        self.proxy_organisation = OrganisationFactory(
+            name="Wikipedia Library OCLC EZProxy"
+        )
+        self.proxy_collection = CollectionFactory(
+            name="EZProxy", organisation=self.proxy_organisation
+        )
+        self.proxy_url_pattern = URLPatternFactory(
+            url="wikipedialibrary.idm.oclc", collection=self.proxy_collection
+        )
+
+        self.linkevent_jstor1 = LinkEventFactory(link="www.jstor.org/dgsajdga")
+        self.linkevent_jstor1.url.add(self.jstor_url_pattern)
+        self.linkevent_jstor2 = LinkEventFactory(link="www.jstor.org/eiuqwyeiu445")
+        self.linkevent_jstor2.url.add(self.jstor_url_pattern)
+        self.linkevent_jstor_proxy = LinkEventFactory(
+            link="www-jstor-org.wikipedialibrary.idm.oclc/eiuqwyeiu445"
+        )
+        self.linkevent_jstor_proxy.url.add(self.proxy_url_pattern)
+
+        self.linkevent_proquest1 = LinkEventFactory(
+            link="www.proquest.com/vclmxvldfgf465"
+        )
+        self.linkevent_proquest1.url.add(self.proquest_url_pattern)
+        self.linkevent_proquest2 = LinkEventFactory(
+            link="www.proquest.com/dkjsahdj2893"
+        )
+        self.linkevent_proquest2.url.add(self.proquest_url_pattern)
+        self.linkevent_proquest_proxy = LinkEventFactory(
+            link="www-proquest-com.wikipedialibrary.idm.oclc/dhsauiydiuq8273"
+        )
+        self.linkevent_proquest_proxy.url.add(self.proxy_url_pattern)
+
+    def test_change_linkevents_to_non_ezproxy_collections_command(self):
+        # Call the commands to fill the aggregates tables
+        call_command("fill_link_aggregates", collections=[collection.pk])
+        call_command("fill_pageproject_aggregates", collections=[collection.pk])
+        call_command("fill_user_aggregates", collections=[collection.pk])
+
+        self.assertEqual(
+            LinkEvent.objects.filter(url=self.jstor_url_pattern).count(), 2
+        )
+        self.assertEqual(
+            LinkEvent.objects.filter(url=self.proquest_url_pattern).count(), 2
+        )
+        self.assertEqual(
+            LinkEvent.objects.filter(url=self.proxy_url_pattern).count(), 2
+        )
+
+        call_command("remove_ezproxy_collection")
+
+        self.assertEqual(
+            LinkEvent.objects.filter(url=self.jstor_url_pattern).count(), 3
+        )
+        self.assertEqual(
+            LinkEvent.objects.filter(url=self.proquest_url_pattern).count(), 3
+        )


### PR DESCRIPTION
## Description
* Created a management command that removes the EZProxy collection, organization and url patterns associated with them and then add that proxied url to the collection it actually belongs to
* Changed the `linkevents_collect` command to do the same going forward

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
When editors cite a resource from The Wikipedia Library, they might have accessed it through EZProxy. These citation events were being missed from our metrics. This PR solves this problem

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T262025](https://phabricator.wikimedia.org/T262025)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Manual testing of the management command and added tests


## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)
**Before, with EZProxy links not included**
![Screen Shot 2021-01-25 at 22 54 37](https://user-images.githubusercontent.com/7854953/105802788-856e5900-5f61-11eb-9d44-e5c203554d27.png)


**After, with the EZProxy links included** 
![Screen Shot 2021-01-25 at 22 54 27](https://user-images.githubusercontent.com/7854953/105802731-64a60380-5f61-11eb-8119-b4f62ec4dfe8.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
