### PR TITLE
Fix on_user_list flag on proxy linkevents

### DIFF
--- a/extlinks/links/management/commands/fix_proxy_linkevents_on_user_list.py
+++ b/extlinks/links/management/commands/fix_proxy_linkevents_on_user_list.py
@@ -1,0 +1,52 @@
+from django.core.management.base import BaseCommand
+from django.core.management import call_command
+
+from extlinks.aggregates.models import (
+    LinkAggregate,
+    PageProjectAggregate,
+    UserAggregate,
+)
+from extlinks.links.models import LinkEvent
+
+
+class Command(BaseCommand):
+    help = "Fixes all those proxy linkevents that aren't in the user list"
+
+    def handle(self, *args, **options):
+        proxy_not_on_user_list_linkevents = LinkEvent.objects.filter(
+            link__contains="wikipedialibrary.idm.oclc", on_user_list=False
+        )
+
+        if proxy_not_on_user_list_linkevents.exists():
+            earliest_link_date = proxy_not_on_user_list_linkevents.earliest(
+                "timestamp"
+            ).timestamp
+            collection_list = set()
+            for linkevent in proxy_not_on_user_list_linkevents:
+                # Get URLPatterns associated with the linkevent
+                urls = linkevent.url.all()
+                # Get the organisation from the first url
+                if urls:
+                    collection = urls[0].collection
+                    collection_list.add(collection.id)
+                    organisation = collection.organisation
+                    username_list = organisation.username_list
+                    if username_list:
+                        if linkevent.username in username_list.all():
+                            linkevent.on_user_list = True
+                            linkevent.save()
+
+            if collection_list:
+                LinkAggregate.objects.filter(
+                    collection__in=collection_list, full_date__gte=earliest_link_date
+                ).delete()
+                PageProjectAggregate.objects.filter(
+                    collection__in=collection_list, full_date__gte=earliest_link_date
+                ).delete()
+                UserAggregate.objects.filter(
+                    collection__in=collection_list, full_date__gte=earliest_link_date
+                ).delete()
+
+                call_command("fill_link_aggregates", collections=collection_list)
+                call_command("fill_pageproject_aggregates", collections=collection_list)
+                call_command("fill_user_aggregates", collections=collection_list)

--- a/extlinks/links/management/commands/remove_ezproxy_collection.py
+++ b/extlinks/links/management/commands/remove_ezproxy_collection.py
@@ -133,8 +133,8 @@ class Command(BaseCommand):
         -------
 
         """
-        linkevents_changed = 0
         for collection in collections:
+            linkevents_changed = 0
             collection_urls = collection.url.all()
             for url_pattern in collection_urls:
                 for linkevent in linkevents:


### PR DESCRIPTION
## Description
Created a management command to change the `on_user_list` flag of a proxy LinkEvent if a user is a part of that organization's user list.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Most of these links must have editors who were on the user list of that organization. Since we do not store historical data about when editors have or have not been on a user list, we will use the current status as the modified `on_user_list` flag.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T273078](https://phabricator.wikimedia.org/T273078)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Manual testing the command and created a test.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**ProQuest Wikilink collection in production with the `Limit to user list flag`**
![Screen Shot 2021-02-05 at 19 14 08](https://user-images.githubusercontent.com/7854953/107104267-7b145080-67e6-11eb-9a60-12a30413bcc0.png)


**ProQuest Wikilink collection in localhost with the `Limit to user list flag`**
![Screen Shot 2021-02-05 at 19 13 59](https://user-images.githubusercontent.com/7854953/107104292-91baa780-67e6-11eb-8098-0058d57d6027.png)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
