### PR TITLE
Use new hostnames for Wiki Replicas

### DIFF
--- a/extlinks/links/management/commands/linksearchtotal_collect.py
+++ b/extlinks/links/management/commands/linksearchtotal_collect.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         total_links_dictionary = {}
         for i, language in enumerate(wiki_list_data):
             db = MySQLdb.connect(
-                host="{lang}wiki.analytics.db.svc.eqiad.wmflabs".format(lang=language),
+                host="{lang}wiki.analytics.db.svc.wikimedia.cloud".format(lang=language),
                 user=os.environ["REPLICA_DB_USER"],
                 passwd=os.environ["REPLICA_DB_PASSWORD"],
                 db="{lang}wiki_p".format(lang=language),


### PR DESCRIPTION
## Description
This simply updates the replica db hostnames to reflect the new replica cluster.

## Rationale
https://wikitech.wikimedia.org/wiki/News/Wiki_Replicas_2020_Redesign#New_host_names

## Phabricator Ticket
N/A

## How Has This Been Tested?
N/A

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
