### PR TITLE
Use nginx proxy cache to serve stale content as needed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,63 +4,80 @@ volumes:
   mysql:
 
 services:
- externallinks:
-   image: quay.io/wikipedialibrary/externallinks:${EXTERNALLINKS_TAG}
-   build:
-     context: .
-     target: externallinks
-   env_file:
-     - '.env'
-   depends_on:
-     - db
-   ports:
-     - "8000:8000"
-   command: ["/app/bin/gunicorn.sh"]
-   volumes:
-     - ./:/app
-     - type: bind
-       source: ${HOST_BACKUP_DIR}
-       target: /app/backup
- db:
-   image: quay.io/wikipedialibrary/mysql:5.7
-   env_file:
-     - '.env'
-   ports:
-     - "3306:3306"
-   command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
-   volumes:
-       - mysql:/var/lib/mysql
-   healthcheck:
-     test: ["CMD", "mysqladmin", "ping", "-h", "localhost","-plinks"]
-     timeout: 20s
-     interval: 10s
-     retries: 10
- nginx:
-   image: quay.io/wikipedialibrary/nginx:latest
-   volumes:
-     - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-     - ./static:/app/static
-   ports:
-     - "80:80"
-   depends_on:
-     - externallinks
- eventstream:
-   image: quay.io/wikipedialibrary/eventstream:${EVENTSTREAM_TAG}
-   build:
-     context: .
-     target: eventstream
-   depends_on:
-     - db
-   env_file:
-     - '.env'
-   command: ["python", "django_wait_for_migrations.py", "linkevents_collect", "--historical"]
-   volumes:
-     - ./:/app
- cache:
-   image: quay.io/wikipedialibrary/memcached:latest
-   ports:
-    - "11211:11211"
-   entrypoint:
-     - memcached
-   depends_on:
-     - externallinks
+  externallinks:
+    image: quay.io/wikipedialibrary/externallinks:${EXTERNALLINKS_TAG}
+    build:
+      context: .
+      target: externallinks
+    env_file:
+      - ".env"
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+    command: ["/app/bin/gunicorn.sh"]
+    volumes:
+      - ./:/app
+      - type: bind
+        source: ${HOST_BACKUP_DIR}
+        target: /app/backup
+  db:
+    image: quay.io/wikipedialibrary/mysql:5.7
+    env_file:
+      - ".env"
+    ports:
+      - "3306:3306"
+    command:
+      [
+        "mysqld",
+        "--character-set-server=utf8mb4",
+        "--collation-server=utf8mb4_unicode_ci",
+      ]
+    volumes:
+      - mysql:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-plinks"]
+      timeout: 20s
+      interval: 10s
+      retries: 10
+  nginx:
+    image: quay.io/wikipedialibrary/nginx:latest
+    volumes:
+      - type: volume
+        target: /var/lib/nginx/cache
+      - type: bind
+        source: ./nginx.conf
+        target: /etc/nginx/conf.d/default.conf
+      - type: bind
+        source: ./static
+        target: /app/static
+    ports:
+      - "80:80"
+    depends_on:
+      - externallinks
+  eventstream:
+    image: quay.io/wikipedialibrary/eventstream:${EVENTSTREAM_TAG}
+    build:
+      context: .
+      target: eventstream
+    depends_on:
+      - db
+    env_file:
+      - ".env"
+    command:
+      [
+        "python",
+        "django_wait_for_migrations.py",
+        "linkevents_collect",
+        "--historical",
+      ]
+    volumes:
+      - ./:/app
+  cache:
+    image: quay.io/wikipedialibrary/memcached:latest
+    ports:
+      - "11211:11211"
+    entrypoint:
+      - memcached
+    depends_on:
+      - externallinks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
       - "8000:8000"
     command: ["/app/bin/gunicorn.sh"]
     volumes:
-      - ./:/app
+      - type: bind
+        source: ./
+        target: /app
       - type: bind
         source: ${HOST_BACKUP_DIR}
         target: /app/backup
@@ -72,7 +74,9 @@ services:
         "--historical",
       ]
     volumes:
-      - ./:/app
+      - type: bind
+        source: ./
+        target: /app
   cache:
     image: quay.io/wikipedialibrary/memcached:latest
     ports:

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -158,10 +158,11 @@ class Command(BaseCommand):
         # case, but I can't wait to find out why I'm wrong.
         on_user_list = False
         this_link_org = url_patterns[0].collection.organisation
-        username_list = this_link_org.username_list
-        if username_list:
-            if username_object in username_list.all():
-                on_user_list = True
+        if hasattr(this_link_org, "username_list"):
+            username_list = this_link_org.username_list
+            if username_list:
+                if username_object in username_list.all():
+                    on_user_list = True
 
         # Log actions such as page moves and image uploads have no
         # revision ID.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,22 +1,90 @@
+map $http_x_forwarded_proto $web_proxy_scheme {
+  default $scheme;
+  https https;
+}
+
+map $http_user_agent $limit_bots {
+  default "";
+  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot) $binary_remote_addr;
+}
+
+## Testing the request method
+# Only GET and HEAD are caching safe.
+map $request_method $no_cache_method {
+  default 1;
+  HEAD 0;
+  GET 0;
+}
+
+## Testing for Cache-Control header
+# Only checking for no-cache because chrome annoyingly sets max-age=0 when hitting enter in the address bar.
+map $http_cache_control $no_cache_control {
+  default 0;
+  no-cache 1;
+}
+
+## Testing for the session cookie being present
+map $http_cookie $no_cache_session {
+  default 0;
+  ~sessionid 1; # Django session cookie
+}
+
+## proxy caching settings.
+proxy_cache_path /var/lib/nginx/cache levels=1:2 keys_zone=cache:8m max_size=10g inactive=10m;
+proxy_cache_key "$scheme$proxy_host$uri$is_args$args$http_accept_language";
+proxy_cache_lock on;
+proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
+
+# remote address is a joke here since we don't have x-forwarded-for
+limit_req_zone $limit_bots zone=bots:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone=one:10m rate=500r/s;
+
 upstream django_server {
  server externallinks:8000 fail_timeout=0;
 }
+
 server {
- listen 80;
- client_max_body_size 4G;
- server_name wikilink.wmflabs.org;
- keepalive_timeout 5;
- location /static/ {
-   root /app/;
-   expires 30d;
- }
- location / {
-   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-   proxy_set_header Host $http_host;
-   proxy_redirect off;
-   if (!-f $request_filename) {
-     proxy_pass http://django_server;
-     break;
-   }
- }
+  listen 80 deferred;
+  client_max_body_size 4G;
+  server_name wikilink.wmflabs.org;
+  keepalive_timeout 5;
+
+  # Definied explicitly to avoid caching
+  location /healthcheck/link_event {
+    # Rate limit
+    limit_req zone=bots burst=2 nodelay;
+    limit_req zone=one burst=1000 nodelay;
+    limit_req_status 429;
+    # Proxy
+    proxy_set_header X-Forwarded-Proto $web_proxy_scheme;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://django_server;
+  }
+
+  location / {
+    root /app/;
+    expires 30d;
+
+    # checks for static file, if not found proxy to app
+    try_files $uri @django;
+  }
+
+  location @django {
+    # Cache
+    proxy_cache_valid 200 301 302 401 403 404 1d;
+    proxy_cache_bypass $http_pragma $no_cache_method $no_cache_control $no_cache_session;
+    proxy_cache_revalidate on;
+    proxy_cache cache;
+    add_header X-Cache-Status $upstream_cache_status;
+    # Rate limit
+    limit_req zone=bots burst=2 nodelay;
+    limit_req zone=one burst=1000 nodelay;
+    limit_req_status 429;
+    # Proxy
+    proxy_set_header X-Forwarded-Proto $web_proxy_scheme;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://django_server;
+  }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ upstream django_server {
 server {
  listen 80;
  client_max_body_size 4G;
- server_name extlinks.wmflabs.org;
+ server_name wikilink.wmflabs.org;
  keepalive_timeout 5;
  location /static/ {
    root /app/;


### PR DESCRIPTION
## Description
- Adds an nginx proxy cache for anonymous users, which allows us to serve content even if the externallinks service is unresponsive
- cleans up some small bugs in the nginx config
- prettifies docker-compose.yml

Also has a quick fix to a bug I discovered post-moving-things around:
```
eventstream_1    | Traceback (most recent call last):
eventstream_1    |   File "django_wait_for_migrations.py", line 59, in <module>
eventstream_1    |     wait_for_migrations(sys.argv)
eventstream_1    |   File "django_wait_for_migrations.py", line 53, in wait_for_migrations
eventstream_1    |     execute_from_command_line(args)
eventstream_1    |   File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
eventstream_1    |     utility.execute()
eventstream_1    |   File "/usr/local/lib/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
eventstream_1    |     self.fetch_command(subcommand).run_from_argv(self.argv)
eventstream_1    |   File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 330, in run_from_argv
eventstream_1    |     self.execute(*args, **cmd_options)
eventstream_1    |   File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 371, in execute
eventstream_1    |     output = self.handle(*args, **options)
eventstream_1    |   File "/app/extlinks/links/management/commands/linkevents_collect.py", line 65, in handle
eventstream_1    |     self._process_events(url)
eventstream_1    |   File "/app/extlinks/links/management/commands/linkevents_collect.py", line 90, in _process_events
eventstream_1    |     self._evaluate_link(event_data)
eventstream_1    |   File "/app/extlinks/links/management/commands/linkevents_collect.py", line 97, in _evaluate_link
eventstream_1    |     self._process_links(
eventstream_1    |   File "/app/extlinks/links/management/commands/linkevents_collect.py", line 121, in _process_links
eventstream_1    |     self._add_linkevent_to_db(unquoted_url, change, event_dict)
eventstream_1    |   File "/app/extlinks/links/management/commands/linkevents_collect.py", line 161, in _add_linkevent_to_db
eventstream_1    |     username_list = this_link_org.username_list
eventstream_1    | AttributeError: 'NoneType' object has no attribute 'username_list'
```

## Rationale
The database service can get swamped/blocked with dependent queries during linkevent processing.
This causes the web interface to timeout. It would be better to serve cached content in this case.

## Phabricator Ticket
https://phabricator.wikimedia.org/T297919

## How Has This Been Tested?
I manually tested:
 - logged in: no cache
 - logged out: cache
 - regular request: cache
 - hard refresh: no cache
 - externallinks service up: cache
 - externallinks service down: cache
 - `/healthcheck/link_event`: no cache

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
