### PR TITLE
Add prefetch_related to single collection filtering in management commands

### DIFF
--- a/extlinks/aggregates/management/commands/fill_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_link_aggregates.py
@@ -26,9 +26,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["collections"]:
             for col_id in options["collections"]:
-                try:
-                    collection = Collection.objects.get(pk=col_id)
-                except Collection.DoesNotExist:
+                collection = (
+                    Collection.objects.filter(pk=col_id).prefetch_related("url").first()
+                )
+                if not collection:
                     raise CommandError(f"Collection '{col_id}' does not exist")
                     self.stdout.write(
                         self.style.ERROR(f"Error: Collection '{col_id}' does not exist")

--- a/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
@@ -26,9 +26,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["collections"]:
             for col_id in options["collections"]:
-                try:
-                    collection = Collection.objects.get(pk=col_id)
-                except Collection.DoesNotExist:
+                collection = (
+                    Collection.objects.filter(pk=col_id).prefetch_related("url").first()
+                )
+                if not collection:
                     raise CommandError(f"Collection '{col_id}' does not exist")
 
                 link_event_filter = self._get_linkevent_filter(collection)

--- a/extlinks/aggregates/management/commands/fill_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_user_aggregates.py
@@ -26,9 +26,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["collections"]:
             for col_id in options["collections"]:
-                try:
-                    collection = Collection.objects.get(pk=col_id)
-                except Collection.DoesNotExist:
+                collection = (
+                    Collection.objects.filter(pk=col_id).prefetch_related("url").first()
+                )
+                if not collection:
                     raise CommandError(f"Collection '{col_id}' does not exist")
 
                 link_event_filter = self._get_linkevent_filter(collection)


### PR DESCRIPTION
## Description
Prefetch related URLs in single collection filtering in management commands

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
URLs were being prefetched when looping through all collections, but not when looping through a determined set of collections.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Manually tested the management commands

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
