### PR TITLE
Add resource quotas to Wikilink services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       - type: bind
         source: ${HOST_BACKUP_DIR}
         target: /app/backup
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.25"
+          memory: "384M"
   db:
     image: quay.io/wikipedialibrary/mysql:5.7
     env_file:
@@ -42,6 +47,11 @@ services:
       timeout: 20s
       interval: 10s
       retries: 10
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.5"
+          memory: "2.5G"
   nginx:
     image: quay.io/wikipedialibrary/nginx:latest
     volumes:
@@ -57,6 +67,11 @@ services:
       - "80:80"
     depends_on:
       - externallinks
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.25"
+          memory: "32M"
   eventstream:
     image: quay.io/wikipedialibrary/eventstream:${EVENTSTREAM_TAG}
     build:
@@ -77,6 +92,11 @@ services:
       - type: bind
         source: ./
         target: /app
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.25"
+          memory: "48M"
   cache:
     image: quay.io/wikipedialibrary/memcached:latest
     ports:
@@ -85,3 +105,8 @@ services:
       - memcached
     depends_on:
       - externallinks
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.25"
+          memory: "32M"


### PR DESCRIPTION
## Description
Adds resource reservations, which only come into play during resource contention on the host.

## Rationale
Occasionally, once of the services will consume 100% of system resources, leaving nothing for the other services to operate. This is the minimum amount of change to try to address that. When there is no contention, services will continue to consume as much as they want.

The initial values here were determined by looking at `docker stats` in production
```
NAME                                                   CPU %     MEM USAGE / LIMIT     MEM % 
production_eventstream                                 5.45%     39.05MiB / 7.773GiB   0.49%
production_nginx                                       0.21%     14.75MiB / 7.773GiB   0.19%
production_externallinks                               0.63%     318MiB / 7.773GiB     4.00%
production_db                                          1.38%     2.245GiB / 7.773GiB   28.88%
production_cache                                       0.05%     10.86MiB / 7.773GiB   0.14%
```

## Phabricator Ticket
https://phabricator.wikimedia.org/T298878

## How Has This Been Tested?
This is effectively untested, due to the difficulty in simulating production conditions in non-production environments for a deployment-specific change like this.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
