### PR TITLE
cache url patterns used in linkevents_collect

### DIFF
--- a/extlinks/aggregates/factories.py
+++ b/extlinks/aggregates/factories.py
@@ -29,7 +29,7 @@ class UserAggregateFactory(factory.django.DjangoModelFactory):
 
     organisation = factory.SubFactory(OrganisationFactory)
     collection = factory.SubFactory(CollectionFactory)
-    username = factory.Faker("name")
+    username = factory.Sequence(lambda n: 'user%d' % n)
     full_date = factory.Faker(
         "date_between_dates",
         date_start=datetime.date(2017, 1, 1),

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -10,7 +10,6 @@ from sseclient import SSEClient as EventSource
 from urllib.parse import unquote
 
 from django.core.management.base import BaseCommand
-from django.core.cache import cache
 
 from extlinks.links.helpers import link_is_tracked
 from extlinks.links.models import LinkEvent, URLPattern

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -10,6 +10,7 @@ from sseclient import SSEClient as EventSource
 from urllib.parse import unquote
 
 from django.core.management.base import BaseCommand
+from django.core.cache import cache
 
 from extlinks.links.helpers import link_is_tracked
 from extlinks.links.models import LinkEvent, URLPattern
@@ -146,13 +147,7 @@ class Command(BaseCommand):
         # an edit from them before now.
         username_object, created = User.objects.get_or_create(username=username)
 
-        # All URL patterns matching this link
-        tracked_urls = URLPattern.objects.all()
-        url_patterns = [
-            pattern
-            for pattern in tracked_urls
-            if pattern.url in link or pattern.get_proxied_url in link
-        ]
+        url_patterns = URLPattern.objects.matches(link)
 
         # We make a hard assumption here that a given link, despite
         # potentially being associated with multiple url patterns, should

--- a/extlinks/links/models.py
+++ b/extlinks/links/models.py
@@ -11,14 +11,14 @@ from django.utils.functional import cached_property
 logger = logging.getLogger("django")
 
 class URLPatternManager(models.Manager):
-    cached_patterns = cache.get('url_pattern_cache')
 
     def cached(self):
-        if not self.cached_patterns:
-            self.cached_patterns = self.all()
+        cached_patterns = cache.get('url_pattern_cache')
+        if not cached_patterns:
+            cached_patterns = self.all()
             logger.info('set url_pattern_cache')
-            cache.set('url_pattern_cache', self.cached_patterns, 60)
-        return self.cached_patterns
+            cache.set('url_pattern_cache', cached_patterns, None)
+        return cached_patterns
 
     def matches(self, link):
         # All URL patterns matching this link
@@ -59,7 +59,7 @@ class URLPattern(models.Model):
 @receiver(post_save, sender=URLPattern)
 def delete_url_pattern_cache(sender, instance, **kwargs):
     if cache.delete('url_pattern_cache'):
-        logger.info('url_pattern_cache deleted')
+        logger.info('delete url_pattern_cache')
 
 class LinkSearchTotal(models.Model):
     class Meta:


### PR DESCRIPTION
## Description
Caches the queryset of url patterns called when saving link events to the db.
Deletes the cache when a url pattern is saved.

## Rationale
This precludes a db tablescan from happening for every event saved.

## Phabricator Ticket
N/A

## How Has This Been Tested?
I restored a backup and ran the linkevent collection container. I measured the time to parse events before and after and found 19% improvement for ingest speed. I also saw lower overall RAM utilization, but I am less confident in a causal relationship with that. I also tested updating and creating url patterns and verified that the cache gets deleted by the save, and recreated by the ingest command.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
