### PR TITLE
linkevents_archive: dump+delete/load eventlinks

### DIFF
--- a/db.cnf
+++ b/db.cnf
@@ -2,3 +2,4 @@
 collation-server = utf8mb4_unicode_ci
 init-connect = SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci
 character-set-server = utf8mb4
+max_allowed_packet=128M

--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -9,60 +9,92 @@ from extlinks.links.models import LinkEvent
 
 logger = logging.getLogger("django")
 chunk = 100000
+this_year = datetime.now().year
 
 
 class Command(BaseCommand):
-    help = "dump + delete or load LinkEvents for a given year"
+    help = "dump & delete or load LinkEvents for a given year"
 
     def dump(self, year):
-        if year < datetime.now().year:
-            for m in range(1, 13):
-                # pad out month for clear filenames
-                month = f"{m:02}"
-                yyyymm = str(year) + str(month)
-                linkevents = LinkEvent.objects.filter(
-                    timestamp__year=year, timestamp__month=month
+        """
+        Export LinkEvents for `year` to gzipped JSON files, then delete them from the database.
+        Breaks the events up into chunks to limit memory usage.
+        """
+        # Loop through each month
+        for m in range(1, 13):
+            # pad out month for clear filenames
+            month = f"{m:02}"
+            yyyymm = str(year) + str(month)
+            # queryset for this year and month
+            linkevents = LinkEvent.objects.filter(
+                timestamp__year=year, timestamp__month=month
+            )
+            if linkevents.count() == 0:
+                logger.info("no events found for " + yyyymm)
+                continue
+            # Determine the number of passes to make by dividng linkevent count by chunk size, rounding up.
+            passes = math.ceil((linkevents.count()) / chunk)
+            logger.info("dumping " + yyyymm + " in " + str(passes) + " passes")
+            for p in range(passes):
+                # Slice the queryset as needed for each pass
+                offset = chunk * p
+                limit = chunk * (p + 1)
+                logger.info("query offset: " + str(offset))
+                logger.info("query limit: " + str(limit))
+                filename = (
+                    "backup/links_linkevent_" + yyyymm + "." + str(p) + ".json.gz"
                 )
-                if linkevents.count() == 0:
-                    logger.info("no events found for " + yyyymm)
-                    continue
-                passes = math.ceil((linkevents.count()) / chunk)
-                logger.info("dumping " + yyyymm + " in " + str(passes) + " passes")
-                for p in range(passes):
-                    offset = chunk * p
-                    limit = chunk * (p + 1)
-                    logger.info("query offset: " + str(offset))
-                    logger.info("query limit: " + str(limit))
-                    filename = (
-                        "backup/links_linkevent_" + yyyymm + "." + str(p) + ".json.gz"
-                    )
-                    logger.info("dumping " + filename)
-                    linkevents_chunk = linkevents.all()[offset:limit]
-                    with gzip.open(filename, "wt", encoding="utf-8") as archive:
-                        archive.write(serializers.serialize("json", linkevents_chunk))
-                logger.info("deleting " + yyyymm + " events from ORM")
-                linkevents.delete()
+                logger.info("dumping " + filename)
+                linkevents_chunk = linkevents.all()[offset:limit]
+
+                # Serialize the records directly in the writer to conserve memory
+                with gzip.open(filename, "wt", encoding="utf-8") as archive:
+                    archive.write(serializers.serialize("json", linkevents_chunk))
+            # Delete the objects from the database after all passes are complete
+            logger.info("deleting " + yyyymm + " events from ORM")
+            linkevents.delete()
 
     def load(self, year):
+        """
+        Import LinkEvents for `year` from gzipped JSON files.
+        Breaks the events up into chunks to limit memory usage.
+        """
+        # Glob matching the expected file names
         pathname = "backup/links_linkevent_" + str(year) + "??.?.json.gz"
         for filename in sorted(glob.glob(pathname)):
             logger.info("loading " + filename)
+            # Deserialize the records directly in the writer to conserve memory
             with gzip.open(filename, "rt", encoding="utf-8") as archive:
                 data = (
                     deserialized.object
                     for deserialized in serializers.deserialize("json", archive)
                 )
+                # bulk_create is much, much faster than looping through the deserialized objects and save, which is what the django docs demonstrate.
                 LinkEvent.objects.bulk_create(data, chunk)
 
     def add_arguments(self, parser):
-        parser.add_argument("action", nargs=1, type=str)
-        parser.add_argument("year", nargs="+", action="extend", type=int)
+        parser.add_argument(
+            "action",
+            nargs=1,
+            type=str,
+            choices=["dump", "load"],
+            help="dump: export LinkEvents to gzipped JSON files, then delete them from the database. load: import LinkEvents from gzipped JSON files.",
+        )
+        parser.add_argument(
+            "year",
+            nargs="+",
+            action="extend",
+            type=int,
+            help="Space delimited list of years to act upon; past years only",
+        )
 
     def handle(self, *args, **options):
         action = options["action"][0]
-        if action:
-            for year in options["year"]:
-                if action == "dump":
-                    self.dump(year)
-                if action == "load":
-                    self.load(year)
+        for year in options["year"]:
+            if year >= this_year:
+                logger.warning("skipping events for " + str(this_year))
+                continue
+            if action == "dump":
+                self.dump(year)
+            if action == "load":
+                self.load(year)

--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
                 timestamp__year=year, timestamp__month=month
             )
             if linkevents.count() == 0:
-                logger.info("no events found for " + yyyymm)
+                logger.info("no link events found for " + yyyymm)
                 continue
             # Determine the number of passes to make by dividng linkevent count by chunk size, rounding up.
             passes = math.ceil((linkevents.count()) / chunk)
@@ -61,6 +61,10 @@ class Command(BaseCommand):
         """
         # Glob matching the expected file names
         pathname = "backup/links_linkevent_" + str(year) + "??.?.json.gz"
+        filenames = sorted(glob.glob(pathname))
+        if not filenames:
+            logger.info("no link event archives found for " + str(year))
+            return
         for filename in sorted(glob.glob(pathname)):
             logger.info("loading " + filename)
             # Deserialize the records directly in the writer to conserve memory

--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+import glob, gzip, logging
+
+from django.core import serializers
+from django.core.management import BaseCommand
+from django.db import IntegrityError
+
+from extlinks.links.models import LinkEvent
+
+logger = logging.getLogger("django")
+chunk = 100000
+
+
+class Command(BaseCommand):
+    help = "dump + delete or load LinkEvents for a given year"
+
+    def dump(self, year):
+        if year < datetime.now().year:
+            for i in range(1, 13):
+                # pad out month for clear filenames
+                month = f"{i:02}"
+                yyyymm = str(year) + str(month)
+                linkevents = LinkEvent.objects.filter(
+                    timestamp__year=year, timestamp__month=month
+                )
+                if linkevents.count() == 0:
+                    logger.info("no events found for " + yyyymm)
+                    continue
+                passes = (linkevents.count() + chunk // 2) // chunk
+                logger.info("dumping " + yyyymm + " in " + str(passes) + " passes")
+                for i in range(passes):
+                    filename = (
+                        "backup/links_linkevent_" + yyyymm + "." + str(i) + ".json.gz"
+                    )
+                    logger.info("dumping " + filename)
+                    linkevents_chunk = linkevents.all()[:chunk]
+                    with gzip.open(filename, "wt", encoding="utf-8") as archive:
+                        archive.write(serializers.serialize("json", linkevents_chunk))
+                logger.info("deleting " + yyyymm + " events from ORM")
+                linkevents.delete()
+
+    def load(self, year):
+        pathname = "backup/links_linkevent_" + str(year) + "??.?.json.gz"
+        for filename in sorted(glob.glob(pathname)):
+            logger.info("loading " + filename)
+            with gzip.open(filename, "rt", encoding="utf-8") as archive:
+                data = (
+                    deserialized.object
+                    for deserialized in serializers.deserialize("json", archive)
+                )
+                try:
+                    LinkEvent.objects.bulk_create(data, chunk)
+                except IntegrityError:
+                    logger.error("failed to load " + filename)
+
+    def add_arguments(self, parser):
+        parser.add_argument("action", nargs=1, type=str)
+        parser.add_argument("year", nargs="+", action="extend", type=int)
+
+    def handle(self, *args, **options):
+        action = options["action"][0]
+        if action:
+            for year in options["year"]:
+                if action == "dump":
+                    self.dump(year)
+                if action == "load":
+                    self.load(year)

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
         # Every time this script is started, find the latest entry in the
         # database, and start the eventstream from there. This ensures that in
         # the event of any downtime, we always maintain 100% data coverage (up
-        # to the ~30 days that the EventStream historical data is kept anyway).
+        # to the ~7 days that the EventStream historical data is kept anyway).
         if options["historical"]:
             all_events = LinkEvent.objects.all()
             if all_events.exists():

--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -79,7 +79,7 @@
         {% endfor %}
       </table>
       <div style="text-align:right;">
-        <a href="{% url 'organisations:csv_all_links' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
+        <a href="{% url 'organisations:csv_all_links' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download {% now "Y" %} CSV</a>
       </div>
     </div>
   {% endfor %}

--- a/extlinks/programs/templates/programs/program_charts_include.html
+++ b/extlinks/programs/templates/programs/program_charts_include.html
@@ -49,7 +49,7 @@
   </div>
   <div class="row">
     <div style="text-align:right;">
-      <a href="{% url 'programs:csv_all_links' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download CSV</a>
+      <a href="{% url 'programs:csv_all_links' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download {% now "Y" %} CSV</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
Adds management command for dumping linkevents from past years out to gzipped json fixture files.
Updates `csv_all_links` downloads to specify that they are for the current year only

## Rationale
We have over 5 million rows in the linkevents table, and most of that data has been aggregated. We do check for duplicate event ids coming through the stream, but we expect them to be happening near to each other in time, not years apart. Dumping these out will allow us a lot more performance headroom on the production system while still preserving the data if we need to recalculate our aggregates for some reason.

## Phabricator Ticket
https://phabricator.wikimedia.org/T330416

## How Has This Been Tested?
I wrote a little script to
1. restore a backup
1. dump (and delete) the linkevents from prior years
1. load those same events

It counts the linkevents between each step
```
#!/usr/bin/env bash
# years="2019 2020 2021 2022"
# Running 2020 only here to save time for the example
years="2020"
bin/restore.sh backup/202302171707.sql.gz
echo 'select COUNT(*) from links_linkevent;' | python manage.py dbshell
python manage.py linkevents_archive dump $years
echo 'select COUNT(*) from links_linkevent;' | python manage.py dbshell
python manage.py linkevents_archive load $years
echo 'select COUNT(*) from links_linkevent;' | python manage.py dbshell
```

In this example, we have the following number of link events for each step
1. 5515516 linkevents after step 1.
1. 4365791 linkevents after step 2.
1. 5515516 linkevents after step 3.

Meaning we have the same number of events after loading as we did before dumping

```
time docker exec -it $(docker ps -aq -f name=production_externallinks | head -n 1) "./archive_test.sh"
DB up.
Dropping existing DB.
Importing backup DB.
Operations to perform:
  Apply all migrations: admin, aggregates, auth, contenttypes, django_cron, links, organisations, programs, sessions
Running migrations:
  No migrations to apply.
Finished restore.
COUNT(*)
5515516
dumping 202001 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202001.0.json.gz
deleting 202001 events from ORM
dumping 202002 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202002.0.json.gz
deleting 202002 events from ORM
dumping 202003 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202003.0.json.gz
deleting 202003 events from ORM
dumping 202004 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202004.0.json.gz
deleting 202004 events from ORM
dumping 202005 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202005.0.json.gz
deleting 202005 events from ORM
dumping 202006 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202006.0.json.gz
deleting 202006 events from ORM
dumping 202007 in 1 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202007.0.json.gz
deleting 202007 events from ORM
dumping 202008 in 2 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202008.0.json.gz
query offset: 100000
query limit: 200000
dumping backup/links_linkevent_202008.1.json.gz
deleting 202008 events from ORM
dumping 202009 in 2 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202009.0.json.gz
query offset: 100000
query limit: 200000
dumping backup/links_linkevent_202009.1.json.gz
deleting 202009 events from ORM
dumping 202010 in 2 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202010.0.json.gz
query offset: 100000
query limit: 200000
dumping backup/links_linkevent_202010.1.json.gz
deleting 202010 events from ORM
dumping 202011 in 2 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202011.0.json.gz
query offset: 100000
query limit: 200000
dumping backup/links_linkevent_202011.1.json.gz
deleting 202011 events from ORM
dumping 202012 in 2 passes
query offset: 0
query limit: 100000
dumping backup/links_linkevent_202012.0.json.gz
query offset: 100000
query limit: 200000
dumping backup/links_linkevent_202012.1.json.gz
deleting 202012 events from ORM
COUNT(*)
4365791
loading backup/links_linkevent_202001.0.json.gz
loading backup/links_linkevent_202002.0.json.gz
loading backup/links_linkevent_202003.0.json.gz
loading backup/links_linkevent_202004.0.json.gz
loading backup/links_linkevent_202005.0.json.gz
loading backup/links_linkevent_202006.0.json.gz
loading backup/links_linkevent_202007.0.json.gz
loading backup/links_linkevent_202008.0.json.gz
loading backup/links_linkevent_202008.1.json.gz
loading backup/links_linkevent_202009.0.json.gz
loading backup/links_linkevent_202009.1.json.gz
loading backup/links_linkevent_202010.0.json.gz
loading backup/links_linkevent_202010.1.json.gz
loading backup/links_linkevent_202011.0.json.gz
loading backup/links_linkevent_202011.1.json.gz
loading backup/links_linkevent_202012.0.json.gz
loading backup/links_linkevent_202012.1.json.gz
COUNT(*)
5515516
```
## Screenshots of your changes (if appropriate):
After dumping, the linkevents table begins with this year:

![image](https://user-images.githubusercontent.com/2986893/221279961-4a4d159c-d05a-4d78-8061-8b7ed561cefe.png)

CSV downloads now show the current year in the button
![image](https://user-images.githubusercontent.com/2986893/221971201-0e140562-2475-4db2-8a8b-26416e4a6fce.png)



## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
