### PR TITLE
Remove CSV all links button and view logic from programs

### DIFF
--- a/extlinks/common/views.py
+++ b/extlinks/common/views.py
@@ -180,10 +180,6 @@ class CSVAllLinkEvents(_CSVDownloadView):
             linkevents = LinkEvent.objects.filter(
                 Q(url__collection__organisation__pk=pk) & queryset_filter
             ).distinct()
-        else:
-            program = Program.objects.get(pk=pk)
-            linkevents = program.get_linkevents()
-            linkevents = linkevents.filter(queryset_filter)
 
         writer = csv.writer(response)
 

--- a/extlinks/programs/templates/programs/program_charts_include.html
+++ b/extlinks/programs/templates/programs/program_charts_include.html
@@ -45,13 +45,6 @@
     </div>
   </div>
   <div class="row" style="margin-top:40px;">
-    <h2>Get link events</h2>
-  </div>
-  <div class="row">
-    <div style="text-align:right;">
-      <a href="{% url 'programs:csv_all_links' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download {% now "Y" %} CSV</a>
-    </div>
-  </div>
 </div>
 <script type="text/javascript">
     var form_data = {{ form_data|safe }};

--- a/extlinks/programs/tests.py
+++ b/extlinks/programs/tests.py
@@ -377,24 +377,6 @@ class ProgramDetailTest(TestCase):
         )
         self.assertEqual(csv_content, expected_output)
 
-    def test_latest_links_csv(self):
-        """
-        Test that the top users CSV returns the expected data
-        """
-        factory = RequestFactory()
-
-        csv_url = reverse("programs:csv_all_links", kwargs={"pk": self.program1.pk})
-
-        request = factory.get(csv_url)
-        response = CSVAllLinkEvents.as_view()(request, pk=self.program1.pk)
-
-        self.assertContains(response, self.linkevent1.link)
-        self.assertContains(response, self.linkevent2.link)
-        self.assertContains(response, self.linkevent3.link)
-        self.assertContains(response, self.linkevent4.link)
-
-        self.assertContains(response, self.linkevent1.username.username)
-
     def test_program_detail_bot_edits(self):
         """
         Test that the user list limiting form works on the program detail page.


### PR DESCRIPTION
## Description
Removed the CSV  download all links button and view logic from programs. The behavior for individual organizations stayed as-is.

## Rationale
Attempting to download all link events was very costly and would break.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T331459](https://phabricator.wikimedia.org/T331459)

## How Has This Been Tested?
Tested manually and automated tests are running correctly.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
