### PR TITLE
Fix django-cron jobs

### DIFF
--- a/extlinks/aggregates/cron.py
+++ b/extlinks/aggregates/cron.py
@@ -4,10 +4,12 @@ from django.core.management import call_command
 
 
 class LinkAggregatesCron(CronJobBase):
-    # Will run daily at midnight UTC
-    schedule = Schedule(run_at_times=["00:00"])
     RETRY_AFTER_FAILURE_MINS = 360
     MIN_NUM_FAILURES = 5
+    # Will run daily at midnight UTC
+    schedule = Schedule(
+        run_at_times=["00:00"], retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
     code = "aggregates.link_aggregates_cron"
 
     def do(self):
@@ -15,10 +17,12 @@ class LinkAggregatesCron(CronJobBase):
 
 
 class UserAggregatesCron(CronJobBase):
-    # Will run daily at 00:05 UTC
-    schedule = Schedule(run_at_times=["00:05"])
     RETRY_AFTER_FAILURE_MINS = 360
     MIN_NUM_FAILURES = 5
+    # Will run daily at 00:05 UTC
+    schedule = Schedule(
+        run_at_times=["00:05"], retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
     code = "aggregates.user_aggregates_cron"
 
     def do(self):
@@ -26,10 +30,12 @@ class UserAggregatesCron(CronJobBase):
 
 
 class PageProjectAggregatesCron(CronJobBase):
-    # Will run daily at 00:45 UTC
-    schedule = Schedule(run_at_times=["00:45"])
     RETRY_AFTER_FAILURE_MINS = 360
     MIN_NUM_FAILURES = 5
+    # Will run daily at 00:45 UTC
+    schedule = Schedule(
+        run_at_times=["00:45"], retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
     code = "aggregates.pageproject_aggregates_cron"
 
     def do(self):

--- a/extlinks/common/cron.py
+++ b/extlinks/common/cron.py
@@ -3,10 +3,12 @@ from django_cron import CronJobBase, Schedule
 
 
 class BackupCron(CronJobBase):
-    # 1440 is daily.
-    schedule = Schedule(run_every_mins=1440)
     RETRY_AFTER_FAILURE_MINS = 120
     MIN_NUM_FAILURES = 2
+    # 1440 is daily.
+    schedule = Schedule(
+        run_every_mins=1440, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
     code = "common.backup"
 
     def do(self):

--- a/extlinks/links/cron.py
+++ b/extlinks/links/cron.py
@@ -4,10 +4,12 @@ from django.core.management import call_command
 
 
 class TotalLinksCron(CronJobBase):
-    # 10080 is weekly.
-    schedule = Schedule(run_every_mins=10080)
     RETRY_AFTER_FAILURE_MINS = 300
     MIN_NUM_FAILURES = 3
+    # 10080 is weekly.
+    schedule = Schedule(
+        run_every_mins=10080, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
     code = "links.total_links_cron"
 
     def do(self):

--- a/extlinks/organisations/cron.py
+++ b/extlinks/organisations/cron.py
@@ -4,9 +4,11 @@ from django.core.management import call_command
 
 
 class UserListsCron(CronJobBase):
-    schedule = Schedule(run_every_mins=60)
     RETRY_AFTER_FAILURE_MINS = 10
     MIN_NUM_FAILURES = 3
+    schedule = Schedule(
+        run_every_mins=60, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
     code = "organisations.user_lists_cron"
 
     def do(self):


### PR DESCRIPTION
## Description
Added the retry_after_failure_mins in the schedule constructor.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
The crons will retry more frequently after failures, which can cause a server overload.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T350295](https://phabricator.wikimedia.org/T350295)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
