### PR TITLE
Change externallinks field in WHERE clause

### DIFF
--- a/extlinks/links/management/commands/linksearchtotal_collect.py
+++ b/extlinks/links/management/commands/linksearchtotal_collect.py
@@ -26,7 +26,9 @@ class Command(BaseCommand):
         total_links_dictionary = {}
         for i, language in enumerate(wiki_list_data):
             db = MySQLdb.connect(
-                host="{lang}wiki.analytics.db.svc.wikimedia.cloud".format(lang=language),
+                host="{lang}wiki.analytics.db.svc.wikimedia.cloud".format(
+                    lang=language
+                ),
                 user=os.environ["REPLICA_DB_USER"],
                 passwd=os.environ["REPLICA_DB_PASSWORD"],
                 db="{lang}wiki_p".format(lang=language),
@@ -47,8 +49,8 @@ class Command(BaseCommand):
 
                     cur.execute(
                         """SELECT COUNT(*) FROM externallinks
-                                WHERE el_index LIKE '{url_start}'
-                                AND el_index LIKE '{url_end}'
+                                WHERE el_to_domain_index LIKE '{url_start}'
+                                AND el_to_domain_index LIKE '{url_end}'
                                 """.format(
                             url_start=url_pattern_start, url_end=url_pattern_end
                         )


### PR DESCRIPTION
## Description
Changed the externallinks field we use in the WHERE clause from el_index to el_to_domain_index to fit the new table schema.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This management command is broken.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T350298](https://phabricator.wikimedia.org/T350298)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
