### PR TITLE
healthcheck: add endpoints for cron jobs

### DIFF
--- a/extlinks/healthcheck/urls.py
+++ b/extlinks/healthcheck/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
 
-from .views import LinkEventHealthCheckView
+from .views import AggregatesCronHealthCheckView, CommonCronHealthCheckView, LinksCronHealthCheckView, OrganizationsCronHealthCheckView, LinkEventHealthCheckView
 
 urlpatterns = [
     path("link_event", LinkEventHealthCheckView.as_view(), name="link_event"),
+    path("agg_crons", AggregatesCronHealthCheckView.as_view(), name="agg_crons"),
+    path("common_crons", CommonCronHealthCheckView.as_view(), name="common_crons"),
+    path("link_crons", LinksCronHealthCheckView.as_view(), name="link_crons"),
+    path("org_crons", OrganizationsCronHealthCheckView.as_view(), name="org_crons"),
 ]

--- a/extlinks/healthcheck/views.py
+++ b/extlinks/healthcheck/views.py
@@ -4,6 +4,7 @@ from django.views import View
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
+from django_cron.models import CronJobLog
 from extlinks.links.models import LinkEvent
 
 @method_decorator(cache_page(60 * 1), name="dispatch")
@@ -23,6 +24,108 @@ class LinkEventHealthCheckView(View):
             else:
                 status_msg = "out of date"
         except LinkEvent.DoesNotExist:
+            status_code = 404
+            status_msg = "not found"
+        response = JsonResponse({"status": status_msg})
+        response.status_code = status_code
+        return response
+
+
+@method_decorator(cache_page(60 * 1), name="dispatch")
+class AggregatesCronHealthCheckView(View):
+    """
+    Healthcheck that passes only if the link aggregate jobs have all run successfully in the last 2 days
+    """
+    def get(self, request, *args, **kwargs):
+        status_code = 500
+        status_msg = "error"
+        try:
+            latest_link_aggregates_cron_endtime = CronJobLog.objects.filter(code="aggregates.link_aggregates_cron", is_success=True).latest("end_time").end_time
+            latest_user_aggregates_cron_endtime = CronJobLog.objects.filter(code="aggregates.user_aggregates_cron", is_success=True).latest("end_time").end_time
+            latest_pageproject_aggregates_cron_endtime = CronJobLog.objects.filter(code="aggregates.pageproject_aggregates_cron", is_success=True).latest("end_time").end_time
+            cutoff_datetime = now() - timedelta(days=2)
+            if latest_link_aggregates_cron_endtime < cutoff_datetime:
+                status_msg = "out of date"
+            elif latest_user_aggregates_cron_endtime < cutoff_datetime:
+                status_msg = "out of date"
+            elif latest_pageproject_aggregates_cron_endtime < cutoff_datetime:
+                status_msg = "out of date"
+            else:
+                status_code = 200
+                status_msg = "ok"
+        except CronJobLog.DoesNotExist:
+            status_code = 404
+            status_msg = "not found"
+        response = JsonResponse({"status": status_msg})
+        response.status_code = status_code
+        return response
+
+
+@method_decorator(cache_page(60 * 1), name="dispatch")
+class CommonCronHealthCheckView(View):
+    """
+    Healthcheck that passes only if the common jobs have all run successfully in the last 2 days
+    """
+    def get(self, request, *args, **kwargs):
+        status_code = 500
+        status_msg = "error"
+        try:
+            latest_common_backup_endtime = CronJobLog.objects.filter(code="common.backup", is_success=True).latest("end_time").end_time
+            cutoff_datetime = now() - timedelta(days=2)
+            if latest_common_backup_endtime < cutoff_datetime:
+                status_msg = "out of date"
+            else:
+                status_code = 200
+                status_msg = "ok"
+        except CronJobLog.DoesNotExist:
+            status_code = 404
+            status_msg = "not found"
+        response = JsonResponse({"status": status_msg})
+        response.status_code = status_code
+        return response
+
+
+@method_decorator(cache_page(60 * 1), name="dispatch")
+class LinksCronHealthCheckView(View):
+    """
+    Healthcheck that passes only if the links jobs have all run successfully in the last 9 days
+    """
+    def get(self, request, *args, **kwargs):
+        status_code = 500
+        status_msg = "error"
+        try:
+            latest_total_links_endtime = CronJobLog.objects.filter(code="links.total_links_cron", is_success=True).latest("end_time").end_time
+            cutoff_datetime = now() - timedelta(days=9)
+            if latest_total_links_endtime < cutoff_datetime:
+                status_msg = "out of date"
+            else:
+                status_code = 200
+                status_msg = "ok"
+        except CronJobLog.DoesNotExist:
+            status_code = 404
+            status_msg = "not found"
+        response = JsonResponse({"status": status_msg})
+        response.status_code = status_code
+        return response
+
+
+@method_decorator(cache_page(60 * 1), name="dispatch")
+class OrganizationsCronHealthCheckView(View):
+    """
+    Healthcheck that passes only if the Organizations jobs have all run successfully in the last 2 hours
+    """
+    def get(self, request, *args, **kwargs):
+        status_code = 500
+        status_msg = "error"
+        try:
+            latest_user_lists_endtime = CronJobLog.objects.filter(code="organisations.user_lists_cron", is_success=True).latest("end_time").end_time
+            cutoff_datetime = now() - timedelta(hours=2)
+            if latest_user_lists_endtime < cutoff_datetime:
+                status_msg = "out of date"
+            else:
+                status_code = 200
+                status_msg = "ok"
+        except CronJobLog.DoesNotExist:
             status_code = 404
             status_msg = "not found"
         response = JsonResponse({"status": status_msg})


### PR DESCRIPTION
## Description
adds the following endpoints:
- /healthcheck/agg_crons
  - healthy if all [aggregate jobs](https://github.com/WikipediaLibrary/externallinks/blob/master/extlinks/aggregates/cron.py) have succeeded in the last 2 days
- /healthcheck/common_crons
  - healthy if [backup job](https://github.com/WikipediaLibrary/externallinks/blob/master/extlinks/common/cron.py) has succeded in the last 2 days
- /healthcheck/link_crons
  - healthy if [links cron](https://github.com/WikipediaLibrary/externallinks/blob/master/extlinks/links/cron.py) has succeded in the last 9 days
- /healthcheck/org_crons
  - healthy if [user list job](https://github.com/WikipediaLibrary/externallinks/blob/master/extlinks/organisations/cron.py) has succeeded within the last 2 hours


## Rationale
This will allow us to get email notifications from an out-of-band system if crons aren't completing successfully

## Phabricator Ticket
https://phabricator.wikimedia.org/T350588

## How Has This Been Tested?
I manually adjusted cron end times and status and verified the behavior across the cutoff thresholds

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
