### PR TITLE
backup: run every 2 days; retain for 2 weeks

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -24,10 +24,10 @@ flock -n ${lockfile}
 
         echo "Finished backup."
 
-        # Retain backups for 30 days.
-        find /app/backup -name "*.sql.gz" -mtime +30 -delete || :
+        # Retain backups for 14 days.
+        find /app/backup -name "*.sql.gz" -mtime +14 -delete || :
 
-        echo "Removed backups created 30 days ago or more."
+        echo "Removed backups created 14 days ago or more."
     else
         exit 1
     fi

--- a/extlinks/common/cron.py
+++ b/extlinks/common/cron.py
@@ -4,9 +4,9 @@ from django_cron import CronJobBase, Schedule
 class BackupCron(CronJobBase):
     RETRY_AFTER_FAILURE_MINS = 120
     MIN_NUM_FAILURES = 2
-    # 1440 is daily.
+    # 2880 is every other day.
     schedule = Schedule(
-        run_every_mins=1440, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+        run_every_mins=2880, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
     )
     code = "common.backup"
 

--- a/extlinks/healthcheck/views.py
+++ b/extlinks/healthcheck/views.py
@@ -64,14 +64,14 @@ class AggregatesCronHealthCheckView(View):
 @method_decorator(cache_page(60 * 1), name="dispatch")
 class CommonCronHealthCheckView(View):
     """
-    Healthcheck that passes only if the common jobs have all run successfully in the last 2 days
+    Healthcheck that passes only if the common jobs have all run successfully in the last 3 days
     """
     def get(self, request, *args, **kwargs):
         status_code = 500
         status_msg = "error"
         try:
             latest_common_backup_endtime = CronJobLog.objects.filter(code="common.backup", is_success=True).latest("end_time").end_time
-            cutoff_datetime = now() - timedelta(days=2)
+            cutoff_datetime = now() - timedelta(days=3)
             if latest_common_backup_endtime < cutoff_datetime:
                 status_msg = "out of date"
             else:


### PR DESCRIPTION
## Description
Reduce backup frequency and retention

## Rationale
Our backups use too much disk space:
- every other day still provides plenty of restore times within our one week of event stream data
- backups older than two weeks are of limited utility because of the amount of data loss due to the event data stream only going back ~7 days

## Phabricator Ticket
https://phabricator.wikimedia.org/T350295

## How Has This Been Tested?
I tested this locally, and it seems to work fine.

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
