### PR TITLE
restore.sh: set nice value to prevent self-DOS

### DIFF
--- a/bin/restore.sh
+++ b/bin/restore.sh
@@ -13,7 +13,7 @@ then
     mysql -h db -u root -p"${MYSQL_ROOT_PASSWORD}" -D "${MYSQL_DATABASE}" -e "DROP DATABASE ${MYSQL_DATABASE}; CREATE DATABASE ${MYSQL_DATABASE};" | :
 
     echo "Importing backup DB."
-    gunzip -c "${restore_file}" | mysql -h db -u root -p"${MYSQL_ROOT_PASSWORD}" -D "${MYSQL_DATABASE}"
+    nice -n 5 bash -c "gunzip -c ${restore_file} | mysql -h db -u root -p${MYSQL_ROOT_PASSWORD} -D ${MYSQL_DATABASE}"
 
     ## Run any necessary DB operations.
     python /app/manage.py migrate


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to Wikilinks (externallinks)!)

## Description
the decompression and db writes can be very cpu and io intensive. Moving the commands into a subshell and setting a nice value on that shell allows other system processes to continue while restoring.

## Rationale
restoring locally rendered my dev toolchain inoperable; it has previously rendered the production system inaccessible via ssh.

## Phabricator Ticket
N/A

## How Has This Been Tested?
This was how I did my most recent local restore

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
