### PR TITLE
Add string truncation in page stats table

### DIFF
--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -285,7 +285,7 @@
           var tdPageName = document.createElement("td");
           var a = document.createElement("a");
           a.href = "https://" + pages[i].project_name + "/wiki/" + pages[i].page_name;
-          a.appendChild(document.createTextNode(pages[i].page_name));
+          a.appendChild(document.createTextNode(truncateString(pages[i].page_name, 40)));
           tdPageName.appendChild(a);
           var tdLinks = document.createElement("td");
           tdLinks.innerHTML = pages[i].links_diff;


### PR DESCRIPTION
## Description
Add string truncation in page stats table

## Rationale
The strings of long article names overflow into the next table

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Tested manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

**Before**
![Screenshot 2024-06-12 at 17 43 58](https://github.com/WikipediaLibrary/externallinks/assets/7854953/99ca99bd-c817-4855-ae46-bdc24cc7bac4)


**After**
![Screenshot 2024-06-12 at 17 43 22](https://github.com/WikipediaLibrary/externallinks/assets/7854953/94dbfd00-4c08-4290-be2e-0b9078337569)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
