### PR TITLE
backup.sh: set nice value to prevent self-DOS

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -17,7 +17,7 @@ flock -n ${lockfile}
     then
         echo "Backing up database."
         filename="/app/backup/${date}.sql.gz"
-        mysqldump -h db -u root -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DATABASE}" | gzip > ${filename}
+        nice -n 5 bash -c "mysqldump -h db -u root -p${MYSQL_ROOT_PASSWORD} ${MYSQL_DATABASE} | gzip > ${filename}"
 
         ## Root only
         chmod 0600 ${filename}


### PR DESCRIPTION
## Description
the compression and mysqldump can be very cpu and io intensive. Moving the commands into a subshell and setting a nice value on that shell allows other system processes to continue while backing up.

## Rationale
It looks like the externallinks container can't reliably access the database while backups are running. Reducing the priority of the gzip and mysqldump processes should help with that

## Phabricator Ticket
N/A

## How Has This Been Tested?
I ran a backup locally while collecting events. The backup finished a little slower, which indicates that it had lower priority during periods of contention.

## Screenshots of your changes (if appropriate):
N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
