### PR TITLE
Add atomic transactions to aggregates commands

### DIFF
--- a/db.cnf
+++ b/db.cnf
@@ -2,4 +2,4 @@
 collation-server = utf8mb4_unicode_ci
 init-connect = SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci
 character-set-server = utf8mb4
-max_allowed_packet=128M
+max_allowed_packet=512M

--- a/extlinks/aggregates/management/commands/fill_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_link_aggregates.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta, datetime
 
 from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
 from django.db.models import Count, Q
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
@@ -68,7 +69,11 @@ class Command(BaseCommand):
         else:
             linkaggregate_filter = Q()
 
-        latest_aggregated_link_date = LinkAggregate.objects.filter(linkaggregate_filter).order_by("full_date").last()
+        latest_aggregated_link_date = (
+            LinkAggregate.objects.filter(linkaggregate_filter)
+            .order_by("full_date")
+            .last()
+        )
 
         if latest_aggregated_link_date is not None:
             latest_datetime = datetime(
@@ -176,11 +181,12 @@ class Command(BaseCommand):
                     existing_link_aggregate.save()
             else:
                 # Create a new link aggregate
-                LinkAggregate.objects.create(
-                    organisation=collection.organisation,
-                    collection=collection,
-                    full_date=link_event["timestamp_date"],
-                    total_links_added=link_event["links_added"],
-                    total_links_removed=link_event["links_removed"],
-                    on_user_list=link_event["on_user_list"],
-                )
+                with transaction.atomic():
+                    LinkAggregate.objects.create(
+                        organisation=collection.organisation,
+                        collection=collection,
+                        full_date=link_event["timestamp_date"],
+                        total_links_added=link_event["links_added"],
+                        total_links_removed=link_event["links_removed"],
+                        on_user_list=link_event["on_user_list"],
+                    )

--- a/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta, datetime
 
 from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
 from django.db.models import Count, Q
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
@@ -68,7 +69,11 @@ class Command(BaseCommand):
         else:
             linkaggregate_filter = Q()
 
-        latest_aggregated_link_date = PageProjectAggregate.objects.filter(linkaggregate_filter).order_by("full_date").last()
+        latest_aggregated_link_date = (
+            PageProjectAggregate.objects.filter(linkaggregate_filter)
+            .order_by("full_date")
+            .last()
+        )
         if latest_aggregated_link_date is not None:
             latest_datetime = datetime(
                 latest_aggregated_link_date.full_date.year,
@@ -177,13 +182,14 @@ class Command(BaseCommand):
                     existing_link_aggregate.save()
             else:
                 # Create a new link aggregate
-                PageProjectAggregate.objects.create(
-                    organisation=collection.organisation,
-                    collection=collection,
-                    page_name=link_event["page_title"],
-                    project_name=link_event["domain"],
-                    full_date=link_event["timestamp_date"],
-                    total_links_added=link_event["links_added"],
-                    total_links_removed=link_event["links_removed"],
-                    on_user_list=link_event["on_user_list"],
-                )
+                with transaction.atomic():
+                    PageProjectAggregate.objects.create(
+                        organisation=collection.organisation,
+                        collection=collection,
+                        page_name=link_event["page_title"],
+                        project_name=link_event["domain"],
+                        full_date=link_event["timestamp_date"],
+                        total_links_added=link_event["links_added"],
+                        total_links_removed=link_event["links_removed"],
+                        on_user_list=link_event["on_user_list"],
+                    )


### PR DESCRIPTION
## Description
- Added atomic transactions when creating new aggregates rows in the management commands
- Increased `max_allowed_packet` in db.cnf

## Rationale
This will help not create duplicate rows in the aggregates tables, which was causing failures in the cron jobs

## Phabricator Ticket
[T366978](https://phabricator.wikimedia.org/T366978)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
