### PR TITLE
Add extra echos to restore script

### DIFF
--- a/bin/restore.sh
+++ b/bin/restore.sh
@@ -9,7 +9,16 @@ restore_file=${1}
 if /app/bin/django_wait_for_db.sh
 then
 
-    echo "Dropping existing DB."
+    echo "This will drop the DB. Proceed [y/N]?"
+    read -p "This will drop the DB. Proceed [y/N]?" -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Exiting..."
+        exit
+    fi
+
+    echo "Dropping existing DB"
     mysql -h db -u root -p"${MYSQL_ROOT_PASSWORD}" -D "${MYSQL_DATABASE}" -e "DROP DATABASE ${MYSQL_DATABASE}; CREATE DATABASE ${MYSQL_DATABASE};" | :
 
     echo "Importing backup DB."


### PR DESCRIPTION
## Description
Added extra echos before dropping the database.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Sometimes, people can accidentally run that command and drop a database with tens of millions of rows.  We'd rather not do that.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
