### PR TITLE
Disallow bots on Wikilink

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,7 @@ map $http_x_forwarded_proto $web_proxy_scheme {
 
 map $http_user_agent $limit_bots {
   default "";
-  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Googlebot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBotGPTBot|DotBot) $binary_remote_addr;
+  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Googlebot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBot|DotBot) $binary_remote_addr;
 }
 
 ## Testing the request method

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,7 @@ map $http_x_forwarded_proto $web_proxy_scheme {
 
 map $http_user_agent $limit_bots {
   default "";
-  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler) $binary_remote_addr;
+  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot) $binary_remote_addr;
 }
 
 ## Testing the request method

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,7 +5,7 @@ map $http_x_forwarded_proto $web_proxy_scheme {
 
 map $http_user_agent $limit_bots {
   default "";
-  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot) $binary_remote_addr;
+  ~*(GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Googlebot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBotGPTBot|DotBot) $binary_remote_addr;
 }
 
 ## Testing the request method


### PR DESCRIPTION
Bug: T368660

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Add bots to nginx config to disallow them from scraping wikilink. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

We have noticed in GlitchTip that there has been an increase in errors when trying to download CSV files from collections. Upon further inspection, we realized that two bots were making requests to collections that did not exist. We should disallow them from the site.

DotBot: https://moz.com/help/moz-procedures/crawlers/dotbot#block-dotbot-from-any-part-of-your-site
FacebookBot: https://developers.facebook.com/docs/sharing/bot/

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

https://phabricator.wikimedia.org/T368660

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
