### PR TITLE
user_lists_cron should be running hourly, not daily, in Wikilink

### DIFF
--- a/extlinks/organisations/cron.py
+++ b/extlinks/organisations/cron.py
@@ -4,10 +4,11 @@ from django.core.management import call_command
 
 
 class UserListsCron(CronJobBase):
-    RETRY_AFTER_FAILURE_MINS = 10
+    RUN_EVERY_MINS = 60
     MIN_NUM_FAILURES = 3
+    RETRY_AFTER_FAILURE_MINS = 10
     schedule = Schedule(
-        run_every_mins=60, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+        run_every_mins=RUN_EVERY_MINS, retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
     )
     code = "organisations.user_lists_cron"
 


### PR DESCRIPTION
Bug: T351654

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)
Update the RUN_EVERY_MINS variable like in the [documentation](https://django-cron.readthedocs.io/en/latest/installation.html). 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
user_lists_cron should be running hourly, not daily, in Wikilink

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T351654

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Ran cron locally. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
