### PR TITLE
Allow running jobs hourly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,28 @@ services:
         reservations:
           cpus: "0.25"
           memory: "384M"
+  crons:
+    image: quay.io/wikipedialibrary/externallinks:${EXTERNALLINKS_TAG}
+    build:
+      context: .
+      target: externallinks
+    env_file:
+      - ".env"
+    depends_on:
+      - db
+    command: ["python", "manage.py", "cronloop"]
+    volumes:
+      - type: bind
+        source: ./
+        target: /app
+      - type: bind
+        source: ${HOST_BACKUP_DIR}
+        target: /app/backup
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.25"
+          memory: "384M"
   db:
     image: quay.io/wikipedialibrary/mariadb:10-updated
     env_file:

--- a/extlinks/settings/base.py
+++ b/extlinks/settings/base.py
@@ -144,6 +144,7 @@ STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # Cron config
+DJANGO_CRON_LOCK_BACKEND = "django_cron.backends.lock.database.DatabaseLock"
 CRON_CLASSES = [
     "extlinks.organisations.cron.UserListsCron",
     "extlinks.aggregates.cron.LinkAggregatesCron",


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to Wikilinks (externallinks)!)

## Description
- switch from host crontab `docker exec -t $(docker ps -q -f name=production_externallinks) python manage.py runcrons` to using a docker swarm service running `python manage.py cronloop`
- switch from default cache-based cron job lock to db-based lock

## Rationale
- switching cron lock providers means we no longer have to have a "dumb" shared timeout for all jobs
- it also means that we can see the active locks in django admin
- switching to a cronloop swarm service makes troubleshooting much easier

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
- I ran this locally and verified that the userlist job now runs hourly.

## Screenshots of your changes (if appropriate):
![image](https://github.com/user-attachments/assets/fca7eefb-fd2c-4caa-90f3-39114893779a)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
