### PR TITLE
Nginx config to disallow bots on wikilink

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -65,7 +65,7 @@ server {
   location / {
     root /app/;
     expires 30d;
-    if ($http_user_agent ~* (GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Googlebot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBot|DotBot) ) {
+    if ($http_user_agent ~* (GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBot) ) {
         return 403;
     }
     # checks for static file, if not found proxy to app

--- a/nginx.conf
+++ b/nginx.conf
@@ -65,7 +65,9 @@ server {
   location / {
     root /app/;
     expires 30d;
-
+    if ($http_user_agent ~* (GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Googlebot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBot|DotBot) ) {
+        return 403;
+    }
     # checks for static file, if not found proxy to app
     try_files $uri @django;
   }


### PR DESCRIPTION
Bug: T368660

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

Attempting to Implement bot blocking in a different way using nginx configuration. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

Stop bots from scraping Wikilink.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

https://phabricator.wikimedia.org/T368660

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
