### PR TITLE
Increase timeout in nginx config for admin paths so we can validate

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -78,7 +78,15 @@ server {
     # checks for static file, if not found proxy to app
     try_files $uri @django;
   }
-
+  location /admin/ {
+    # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
+    proxy_connect_timeout 120s;
+    proxy_send_timeout 120s;
+    proxy_read_timeout 120s;
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
+    send_timeout 120s;
+    keepalive_timeout 120s;
+  }
   location @django {
     # Cache
     proxy_cache_valid 200 301 302 401 403 404 1d;

--- a/nginx.conf
+++ b/nginx.conf
@@ -78,7 +78,7 @@ server {
     # checks for static file, if not found proxy to app
     try_files $uri @django;
   }
-  location /admin/ {
+  location /admin/links/ {
     # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
     proxy_connect_timeout 120s;
     proxy_send_timeout 120s;


### PR DESCRIPTION
generic relationships on LinkEvents

Bug: T370901

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

- Increased proxy_connect_timeout, proxy_send_timeout, and proxy_read_timeout to 120 seconds for admin path. 
- Increased send_timeout and keepalive_timeout to 120 seconds for admin path.

## Rationale

So we can validate if the generic relationship migration is successful, and to allow the admin dashboard some extra time. 

## Phabricator Ticket
https://phabricator.wikimedia.org/T370901

## How Has This Been Tested?
Not tested since we only have one environment 

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
