### PR TITLE
This moves the django admin relationship display from LinkEvents to U…

### DIFF
--- a/extlinks/aggregates/admin.py
+++ b/extlinks/aggregates/admin.py
@@ -13,6 +13,7 @@ class LinkAggregateAdmin(admin.ModelAdmin):
         "on_user_list",
     )
     list_filter = ("organisation", "collection", "month", "year", "on_user_list")
+    list_select_related = ["organisation", "collection"]
 
 
 admin.site.register(LinkAggregate, LinkAggregateAdmin)
@@ -29,7 +30,7 @@ class UserAggregateAdmin(admin.ModelAdmin):
         "on_user_list",
     )
     list_filter = ("organisation", "collection", "month", "year", "on_user_list")
-
+    list_select_related = ["organisation", "collection"]
 
 admin.site.register(UserAggregate, UserAggregateAdmin)
 
@@ -46,6 +47,6 @@ class PageProjectAggregateAdmin(admin.ModelAdmin):
         "on_user_list",
     )
     list_filter = ("organisation", "collection", "month", "year", "on_user_list")
-
+    list_select_related = ["organisation", "collection"]
 
 admin.site.register(PageProjectAggregate, PageProjectAggregateAdmin)

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.contrib.contenttypes.admin import GenericTabularInline, GenericStackedInline
+from django.contrib.contenttypes.admin import GenericTabularInline
 
 from .models import URLPattern, LinkSearchTotal, LinkEvent
 
@@ -7,12 +7,14 @@ from .models import URLPattern, LinkSearchTotal, LinkEvent
 class LinkEventURLPatternAdminInline(GenericTabularInline):
     model = LinkEvent
     show_change_link = True
-    exclude = ['username', 'user_id', 'on_user_list', 'url']
+    exclude = ['user_id', 'url']
+    readonly_fields = ['link', 'timestamp', 'domain', 'rev_id',
+                       'page_title', 'page_namespace', 'event_id', 'user_is_bot',
+                       'hash_link_event_id', 'change', 'username', 'on_user_list']
 
 
 class URLPatternAdmin(admin.ModelAdmin):
     list_display = ("url",)
-    list_select_related = ["collection"]
     inlines = [
         LinkEventURLPatternAdminInline,
     ]
@@ -31,7 +33,7 @@ admin.site.register(LinkSearchTotal, LinkSearchTotalAdmin)
 class LinkEventAdmin(admin.ModelAdmin):
     list_display = ("link", "timestamp", "domain", "username", "change")
     list_select_related = ["username", "content_type"]
-    readonly_fields = ["url_pattern_display"]
+    readonly_fields = ["url_pattern_display", "username"]
     exclude = ["content_type", "object_id", "url"]
 
     @admin.display(description="URLPattern")

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -6,10 +6,13 @@ from .models import URLPattern, LinkSearchTotal, LinkEvent
 
 class LinkEventURLPatternAdminInline(GenericTabularInline):
     model = LinkEvent
+    show_change_link = True
+    exclude = ['username', 'user_id', 'on_user_list', 'url']
 
 
 class URLPatternAdmin(admin.ModelAdmin):
     list_display = ("url",)
+    list_select_related = ["collection"]
     inlines = [
         LinkEventURLPatternAdminInline,
     ]
@@ -27,6 +30,7 @@ admin.site.register(LinkSearchTotal, LinkSearchTotalAdmin)
 
 class LinkEventAdmin(admin.ModelAdmin):
     list_display = ("link", "timestamp", "domain", "username", "change")
+    list_select_related = ["username", "content_type"]
     readonly_fields = ["url_pattern_display"]
     exclude = ["content_type", "object_id"]
 

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -32,7 +32,7 @@ class LinkEventAdmin(admin.ModelAdmin):
     list_display = ("link", "timestamp", "domain", "username", "change")
     list_select_related = ["username", "content_type"]
     readonly_fields = ["url_pattern_display"]
-    exclude = ["content_type", "object_id"]
+    exclude = ["content_type", "object_id", "url"]
 
     @admin.display(description="URLPattern")
     def url_pattern_display(self, instance):

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -1,10 +1,18 @@
 from django.contrib import admin
+from django.contrib.contenttypes.admin import GenericTabularInline, GenericStackedInline
 
 from .models import URLPattern, LinkSearchTotal, LinkEvent
 
 
+class LinkEventURLPatternAdminInline(GenericTabularInline):
+    model = LinkEvent
+
+
 class URLPatternAdmin(admin.ModelAdmin):
     list_display = ("url",)
+    inlines = [
+        LinkEventURLPatternAdminInline,
+    ]
 
 
 admin.site.register(URLPattern, URLPatternAdmin)
@@ -19,6 +27,12 @@ admin.site.register(LinkSearchTotal, LinkSearchTotalAdmin)
 
 class LinkEventAdmin(admin.ModelAdmin):
     list_display = ("link", "timestamp", "domain", "username", "change")
+    readonly_fields = ["url_pattern_display"]
+    exclude = ["content_type", "object_id"]
+
+    @admin.display(description="URLPattern")
+    def url_pattern_display(self, instance):
+        return URLPattern.objects.filter(pk=instance.content_object.pk).first()
 
 
 admin.site.register(LinkEvent, LinkEventAdmin)

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -7,14 +7,26 @@ from .models import URLPattern, LinkSearchTotal, LinkEvent
 class LinkEventURLPatternAdminInline(GenericTabularInline):
     model = LinkEvent
     show_change_link = True
-    exclude = ['user_id', 'url']
-    readonly_fields = ['link', 'timestamp', 'domain', 'rev_id',
-                       'page_title', 'page_namespace', 'event_id', 'user_is_bot',
-                       'hash_link_event_id', 'change', 'username', 'on_user_list']
+    exclude = ["user_id", "url"]
+    readonly_fields = [
+        "link",
+        "timestamp",
+        "domain",
+        "rev_id",
+        "page_title",
+        "page_namespace",
+        "event_id",
+        "user_is_bot",
+        "hash_link_event_id",
+        "change",
+        "username",
+        "on_user_list",
+    ]
 
 
 class URLPatternAdmin(admin.ModelAdmin):
     list_display = ("url",)
+    exclude = ["collections"]
     inlines = [
         LinkEventURLPatternAdminInline,
     ]

--- a/extlinks/organisations/admin.py
+++ b/extlinks/organisations/admin.py
@@ -22,6 +22,7 @@ admin.site.register(Organisation, OrganisationAdmin)
 class CollectionAdmin(admin.ModelAdmin):
     list_display = ("name", "organisation")
     list_filter = ("name", "organisation")
+    list_select_related = ["organisation"]
 
 
 admin.site.register(Collection, CollectionAdmin)

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,19 +75,36 @@ server {
         return 403;
     }
     location /admin/links/ {
-        # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
-        proxy_connect_timeout 120s;
-        proxy_send_timeout 120s;
-        proxy_read_timeout 120s;
-        # https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
-        send_timeout 120s;
-        keepalive_timeout 120s;
+       try_files $uri @django-admin-slow
     }
-
     # checks for static file, if not found proxy to app
     try_files $uri @django;
   }
   location @django {
+    # Cache
+    proxy_cache_valid 200 301 302 401 403 404 1d;
+    proxy_cache_bypass $http_pragma $no_cache_method $no_cache_control $no_cache_session;
+    proxy_cache_revalidate on;
+    proxy_cache cache;
+    add_header X-Cache-Status $upstream_cache_status;
+    # Rate limit
+    limit_req zone=bots burst=2 nodelay;
+    limit_req zone=one burst=1000 nodelay;
+    limit_req_status 429;
+    # Proxy
+    proxy_set_header X-Forwarded-Proto $web_proxy_scheme;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://django_server;
+  }
+  location @django-admin-slow {
+    # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
+    proxy_connect_timeout 120s;
+    proxy_send_timeout 120s;
+    proxy_read_timeout 120s;
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
+    send_timeout 120s;
+    keepalive_timeout 120s;
     # Cache
     proxy_cache_valid 200 301 302 401 403 404 1d;
     proxy_cache_bypass $http_pragma $no_cache_method $no_cache_control $no_cache_session;

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,7 +75,7 @@ server {
         return 403;
     }
     location /admin/links/ {
-       try_files $uri @django-admin-slow
+        try_files $uri @django-admin-slow;
     }
     # checks for static file, if not found proxy to app
     try_files $uri @django;

--- a/nginx.conf
+++ b/nginx.conf
@@ -74,18 +74,18 @@ server {
     if ($http_user_agent ~* (GoogleBot|bingbot|YandexBot|mj12bot|Apache-HttpClient|Adsbot|Barkrowler|FacebookBot|dotbot|Bytespider|SemrushBot|AhrefsBot|Amazonbot|GPTBot) ) {
         return 403;
     }
+    location /admin/links/ {
+        # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
+        proxy_connect_timeout 120s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+        # https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
+        send_timeout 120s;
+        keepalive_timeout 120s;
+    }
 
     # checks for static file, if not found proxy to app
     try_files $uri @django;
-  }
-  location /admin/links/ {
-    # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
-    proxy_connect_timeout 120s;
-    proxy_send_timeout 120s;
-    proxy_read_timeout 120s;
-    # https://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout
-    send_timeout 120s;
-    keepalive_timeout 120s;
   }
   location @django {
     # Cache


### PR DESCRIPTION
…RLPatterns

- See https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#using-generic-relations-as-an-inline for documentation on generic relationships displaying in django admin

Bug: T370901

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

When we migrated LinkEvents to use generic relationships for URLPatterns we lost the ability to view URLPattern relationships in the admin dashboard. 

## Rationale

This pull request addresses the above issue by moving the relationship display to the URLPattern admin view instead of LinkEvent view. 
This pull request also addresses adding a display field to the LinkEvent admin view that shows the URLPattern url.  

## Phabricator Ticket
https://phabricator.wikimedia.org/T370901

## How Has This Been Tested?

1. Login to admin dashboard
2. Navigate to LinkEvents and click into an individual link 

You should see a readonly property that contains the URLPattern.

4. Navigate to URLPatterns

You should see a table that displays all of the associated LinkEvents for that URLPattern. 



## Screenshots of your changes (if appropriate):


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
