### PR TITLE
Improve performance of URLPattern admin

### DIFF
--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -6,7 +6,8 @@ from .models import URLPattern, LinkSearchTotal, LinkEvent
 
 class LinkEventURLPatternAdminInline(GenericTabularInline):
     model = LinkEvent
-    show_change_link = True
+    # Although not ideal, changing this to False has improved performance
+    show_change_link = False
     exclude = ["user_id", "url"]
     readonly_fields = [
         "link",

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -27,6 +27,7 @@ class LinkEventURLPatternAdminInline(GenericTabularInline):
 class URLPatternAdmin(admin.ModelAdmin):
     list_display = ("url",)
     exclude = ["collections"]
+    autocomplete_fields = ["collection"]
     inlines = [
         LinkEventURLPatternAdminInline,
     ]

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -23,6 +23,11 @@ class LinkEventURLPatternAdminInline(GenericTabularInline):
         "on_user_list",
     ]
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+
+        return qs.select_related("username")
+
 
 class URLPatternAdmin(admin.ModelAdmin):
     list_display = ("url",)

--- a/extlinks/links/admin.py
+++ b/extlinks/links/admin.py
@@ -44,6 +44,7 @@ admin.site.register(URLPattern, URLPatternAdmin)
 
 class LinkSearchTotalAdmin(admin.ModelAdmin):
     list_display = ("url", "date", "total")
+    list_select_related = ["url"]
 
 
 admin.site.register(LinkSearchTotal, LinkSearchTotalAdmin)

--- a/extlinks/organisations/admin.py
+++ b/extlinks/organisations/admin.py
@@ -23,6 +23,7 @@ class CollectionAdmin(admin.ModelAdmin):
     list_display = ("name", "organisation")
     list_filter = ("name", "organisation")
     list_select_related = ["organisation"]
+    search_fields = ["name"]
 
 
 admin.site.register(Collection, CollectionAdmin)


### PR DESCRIPTION
## Description
- Added `autocomplete_fields` to URLPattern admin view 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
We need to be able to look at link events and URL patterns in the admin views.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T370901](https://phabricator.wikimedia.org/T370901)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
