### PR TITLE
linkevents_archive: Rework command to split archives by date

### DIFF
--- a/extlinks/common/urls.py
+++ b/extlinks/common/urls.py
@@ -3,7 +3,6 @@ from django.urls import path
 from extlinks.common.views import (
     CSVProjectTotals,
     CSVUserTotals,
-    CSVAllLinkEvents,
 )
 
 # Shared URL paths. These get namespaced by each app's urlpatterns.
@@ -14,5 +13,4 @@ urlpatterns = [
         name="csv_project_totals",
     ),
     path("<int:pk>/csv/user_totals", CSVUserTotals.as_view(), name="csv_user_totals"),
-    path("<int:pk>/csv/all_links", CSVAllLinkEvents.as_view(), name="csv_all_links"),
 ]

--- a/extlinks/common/views.py
+++ b/extlinks/common/views.py
@@ -172,46 +172,6 @@ class CSVUserTotals(_CSVDownloadView):
             )
 
 
-class CSVAllLinkEvents(_CSVDownloadView):
-    def _write_data(self, response):
-        pk = self.kwargs["pk"]
-        # If we came from an organisation page:
-        if "/organisation" in self.request.build_absolute_uri():
-            organisation = Organisation.objects.get(pk=pk)
-            if organisation:
-                url_patterns = URLPattern.objects.filter(collections__organisation=organisation)
-                url_pattern_type = ContentType.objects.get_for_model(URLPattern)
-                linkevents = LinkEvent.objects.filter(content_type__pk=url_pattern_type.id, object_id__in=url_patterns)
-        writer = csv.writer(response)
-
-        writer.writerow(
-            [
-                "Link",
-                "User",
-                "Bot user",
-                "Page title",
-                "Project",
-                "Timestamp",
-                "Revision ID",
-                "Change",
-            ]
-        )
-
-        for link in linkevents.order_by("-timestamp"):
-            writer.writerow(
-                [
-                    link.link,
-                    link.username,
-                    link.user_is_bot,
-                    link.page_title,
-                    link.domain,
-                    link.timestamp,
-                    link.rev_id,
-                    link.change,
-                ]
-            )
-
-
 def _get_queryset_filter(pk, uri, filters):
     """
     This function returns a Q object with filters depending on which URL a user

--- a/extlinks/links/cron.py
+++ b/extlinks/links/cron.py
@@ -14,3 +14,16 @@ class TotalLinksCron(CronJobBase):
 
     def do(self):
         call_command("linksearchtotal_collect")
+
+
+class ArchiveLinksCron(CronJobBase):
+    RETRY_AFTER_FAILURE_MINS = 300
+    MIN_NUM_FAILURES = 3
+    # Will run daily at 02:00 UTC
+    schedule = Schedule(
+        run_at_times=["02:00"], retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS
+    )
+    code = "links.archive_links_cron"
+
+    def do(self):
+        call_command("linkevents_archive")

--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -1,72 +1,140 @@
-from datetime import datetime
-import glob, gzip, logging, math
+import gzip, logging, datetime, os
+
+from typing import List, Optional
 
 from django.core import serializers
-from django.core.management import call_command, BaseCommand
-from django.db import IntegrityError
+from django.core.management import BaseCommand, call_command
+from django.db import connection
+from django.db.models import Q, Max
+from django_cron.models import CronJobLog
 
-from extlinks.links.models import LinkEvent, URLPattern
+from extlinks.links.models import LinkEvent
 
 logger = logging.getLogger("django")
-chunk = 100000
-this_year = datetime.now().year
+
+CHUNK_SIZE = 10_000
 
 
 class Command(BaseCommand):
-    help = "dump & delete or load LinkEvents for a given year"
+    help = "dump & delete or load LinkEvents"
 
-    def dump(self, year):
+    def dump(self, date: Optional[datetime.date] = None, output: Optional[str] = None):
         """
-        Export LinkEvents for `year` to gzipped JSON files, then delete them from the database.
-        Breaks the events up into chunks to limit memory usage.
+        Export LinkEvents to gzipped JSON files that are grouped by day, and
+        then delete them from the database.
+
+        This command only archives LinkEvents that have been aggregated by
+        checking the cron job log. Optionally a date (YYYY-MM-DD) can be passed
+        as a parameter to override this behavior.
         """
-        # Loop through each month
-        for m in range(1, 13):
-            # pad out month for clear filenames
-            month = f"{m:02}"
-            yyyymm = str(year) + str(month)
-            # queryset for this year and month
-            linkevents = LinkEvent.objects.filter(
-                timestamp__year=year, timestamp__month=month
-            )
-            if linkevents.count() == 0:
-                logger.info("No link events found for " + yyyymm)
-                continue
-            # Determine the number of passes to make by dividng linkevent count by chunk size, rounding up.
-            passes = math.ceil((linkevents.count()) / chunk)
-            logger.info("Dumping " + yyyymm + " in " + str(passes) + " passes")
-            for p in range(passes):
-                # Slice the queryset as needed for each pass
-                offset = chunk * p
-                limit = chunk * (p + 1)
-                logger.info("query offset: " + str(offset))
-                logger.info("query limit: " + str(limit))
-                filename = (
-                    "backup/links_linkevent_" + yyyymm + "." + str(p) + ".json.gz"
+
+        output_dir = output if output and os.path.isdir(output) else "backup"
+
+        if date is None:
+            # We don't want to archive link events that haven't been processed by
+            # the aggregate jobs yet. Find the start time for the most recent
+            # successful aggregate job run grouped by the job name.
+            most_recent_aggregates = list(
+                CronJobLog.objects.values("code")
+                .annotate(last_run=Max("start_time"))
+                .filter(
+                    Q(
+                        code__in=[
+                            "aggregates.link_aggregates_cron",
+                            "aggregates.user_aggregates_cron",
+                            "aggregates.pageproject_aggregates_cron",
+                        ]
+                    )
+                    & Q(is_success=True)
                 )
-                logger.info("dumping " + filename)
-                linkevents_chunk = linkevents.all()[offset:limit]
+            )
+            if len(most_recent_aggregates) != 3:
+                logger.info("All of the aggregate jobs have not been run yet")
+                return
 
-                # Serialize the records directly in the writer to conserve memory
-                with gzip.open(filename, "wt", encoding="utf-8") as archive:
-                    archive.write(serializers.serialize("json", linkevents_chunk))
-            # Delete the objects from the database after all passes are complete
-            logger.info("Deleting " + yyyymm + " events from ORM")
-            linkevents.delete()
+            # Find the oldest start time of the 3 jobs start datetimes we have. All
+            # link events before this date have already been aggregated and are
+            # safe to be archived.
+            archive_start_time = min(
+                map(
+                    lambda result: result["last_run"],
+                    most_recent_aggregates,
+                )
+            ).date()
+        else:
+            archive_start_time = date + datetime.timedelta(days=1)
 
-    def load(self, year):
+        start = archive_start_time - datetime.timedelta(days=1)
+        total = 0
+        iteration = 0
+
+        # Page through LinkEvents for all days prior to the day that all of the
+        # most recent aggregation jobs have started. This should be yesterday's
+        # date, but if the jobs haven't all been completed yet then it will
+        # probably be the day before yesterday.
+        while True:
+            limit = (iteration + 1) * CHUNK_SIZE
+            offset = iteration * CHUNK_SIZE
+
+            # Paginate through LinkEvents in chunks of 10k at a time. Overfetch
+            # an extra record so we can determine if we need to paginate more.
+            results = list(
+                LinkEvent.objects.filter(
+                    timestamp__gte=start,
+                    timestamp__lt=start + datetime.timedelta(days=1),
+                ).all()[offset : limit + 1]
+            )
+            if len(results) == 0:
+                break
+
+            # Remove the overfetched record before saving the archive.
+            linkevents_by_date = results[:CHUNK_SIZE]
+
+            filename = os.path.join(
+                output_dir,
+                f"links_linkevent_{start.strftime('%Y%m%d')}_{iteration}.json.gz",
+            )
+            logger.info(
+                "Dumping %d LinkEvents into %s", len(linkevents_by_date), filename
+            )
+
+            # Serialize the records directly in the writer to conserve memory.
+            with gzip.open(filename, "wt", encoding="utf-8") as archive:
+                archive.write(serializers.serialize("json", linkevents_by_date))
+
+            if len(results) > CHUNK_SIZE:
+                iteration += 1
+            else:
+                start -= datetime.timedelta(days=1)
+                iteration = 0
+
+            total += len(linkevents_by_date)
+
+        logger.info(
+            "Deleting %d LinkEvents before %s from the database",
+            total,
+            archive_start_time.strftime("%Y-%m-%d"),
+        )
+
+        # Delete the objects from the database after all passes are complete.
+        # Do this in batches of 10k as well as this has the possibility of
+        # failing when dealing with a lot of records.
+        query_set = LinkEvent.objects.filter(timestamp__lt=archive_start_time)
+        while query_set.exists():
+            delete_query_set = query_set[:CHUNK_SIZE].values_list("id", flat=True)
+            LinkEvent.objects.filter(pk__in=list(delete_query_set)).delete()
+
+
+    def load(self, filenames: List[str]):
         """
-        Import LinkEvents for `year` from gzipped JSON files.
-        Breaks the events up into chunks to limit memory usage.
+        Import LinkEvents from gzipped JSON files.
         """
-        # Glob matching the expected file names
-        pathname = "backup/links_linkevent_" + str(year) + "??.?.json.gz"
-        filenames = sorted(glob.glob(pathname))
-        ThroughModel = LinkEvent.url.through
+
         if not filenames:
-            logger.info("No link event archives found for " + str(year))
+            logger.info("No link event archives specified")
             return
-        for filename in sorted(glob.glob(pathname)):
+
+        for filename in sorted(filenames):
             logger.info("Loading " + filename)
             # loaddata supports gzipped fixtures and handles relationships properly
             call_command("loaddata", filename)
@@ -80,20 +148,29 @@ class Command(BaseCommand):
             help="dump: Export LinkEvents to gzipped JSON files, then delete them from the database. load: Import LinkEvents from gzipped JSON files.",
         )
         parser.add_argument(
-            "year",
-            nargs="+",
-            action="extend",
-            type=int,
-            help="Space delimited list of years to act upon; past years only",
+            "filenames",
+            nargs="*",
+            type=str,
+            help="LinkEvent archive filenames to load.",
+        )
+        parser.add_argument(
+            "-d",
+            "--date",
+            nargs="?",
+            type=lambda arg: datetime.datetime.strptime(arg, "%Y-%m-%d").date(),
+            help="A maximum date formatted as YYYY-MM-DD to begin archiving from.",
+        )
+        parser.add_argument(
+            "-o",
+            "--output",
+            nargs="?",
+            type=str,
+            help="The directory that the archives containing the LinkEvents should be written to.",
         )
 
     def handle(self, *args, **options):
         action = options["action"][0]
-        for year in options["year"]:
-            if year >= this_year:
-                logger.warning("Skipping events for " + str(this_year))
-                continue
-            if action == "dump":
-                self.dump(year)
-            if action == "load":
-                self.load(year)
+        if action == "dump":
+            self.dump(date=options["date"], output=options["output"])
+        if action == "load":
+            self.load(filenames=options["filenames"])

--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -73,8 +73,8 @@
       <h3>Latest link events</h3>
       <table id="{{ collection.collection_id }}-link-events-table" class="table">
         <tr id="{{ collection.collection_id }}-link-events-button-container">
-          <td> <button id="{{ collection.collection_id }}-link-events-load-button" 
-              onclick='getLatestLinkEvents({{ collection.collection_id|safe }}, {{ form_data|safe }})' 
+          <td> <button id="{{ collection.collection_id }}-link-events-load-button"
+              onclick='getLatestLinkEvents({{ collection.collection_id|safe }}, {{ form_data|safe }})'
               class="btn btn-outline-primary"> Load Latest Link Events</button> </td>
         </tr>
         <tr id="{{ collection.collection_id }}-link-events-table-header">
@@ -85,9 +85,6 @@
           <th>Timestamp</th>
         </tr>
       </table>
-      <div style="text-align:right;">
-        <a href="{% url 'organisations:csv_all_links' pk=object.pk %}?{{ query_string }}" class="btn btn-outline-primary">Download {% now "Y" %} CSV</a>
-      </div>
     </div>
   {% endfor %}
 </div>
@@ -384,7 +381,7 @@
       }
     });
   }
-  
+
   function getLatestLinkEvents(collection_id, form_data){
     var idSpinnerLinkEvents = collection_id + "-loading-spinner-latest-link-events";
     var idLinkEventsTable = collection_id + "-link-events-table";

--- a/extlinks/organisations/tests.py
+++ b/extlinks/organisations/tests.py
@@ -9,7 +9,6 @@ from extlinks.common.views import (
     CSVPageTotals,
     CSVProjectTotals,
     CSVUserTotals,
-    CSVAllLinkEvents,
 )
 from extlinks.links.factories import LinkEventFactory, URLPatternFactory
 from extlinks.links.models import LinkEvent
@@ -354,25 +353,6 @@ class OrganisationDetailTest(TestCase):
             "Username,Links added,Links removed,Net Change\r\n" "Jim,2,0,2\r\n"
         )
         self.assertEqual(csv_content, expected_output)
-
-    def test_latest_links_csv(self):
-        """
-        Test that the top users CSV returns the expected data
-        """
-        factory = RequestFactory()
-
-        csv_url = reverse(
-            "organisations:csv_all_links", kwargs={"pk": self.organisation1.pk}
-        )
-
-        request = factory.get(csv_url)
-        response = CSVAllLinkEvents.as_view()(request, pk=self.organisation1.pk)
-        self.assertContains(response, self.linkevent1.link)
-        self.assertContains(response, self.linkevent2.link)
-        self.assertContains(response, self.linkevent3.link)
-        self.assertContains(response, self.linkevent4.link)
-
-        self.assertContains(response, self.linkevent1.username.username)
 
     def test_bot_edits_form(self):
         """


### PR DESCRIPTION
## Description

This patch changes the linkevents_archive command to archive LinkEvents by day rather than by year. Previously this command would archive LinkEvents by year and split them into multiple chunks of 100k records.

### Changes

* Removed the 'year' parameter and handling.
* Added an optional 'date' parameter to linkevents_archive that the command scans backwards from.
* Added an optional 'output' parameter to linkevents_archive to tell it where to put the archives. This defaults to 'backup' and this option is used by the tests.
* Added a cron job that archives LinkEvents daily at 02:00 UTC.
* When 'date' is left unspecified (e.g. from the cron job) then a safe date to begin archiving from is determined by checking when the aggregation jobs have most recently completed.
* Added tests for the archive command's dump and load subcommands.
* Removed the 'Download YYYY Links CSV' button from the frontend and also the associated CSVAllLinkEvents view since with the removal of the button nothing else is using that view.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

The LinkEvents table has been getting too large as it accumulates ~32000 records per day and is only archived once per year. This patch changes the LinkEvents archival command to support a singular day instead of a year and sets up a cron job that runs it daily.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

https://phabricator.wikimedia.org/T370896

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

Automated tests have been added for the dump and load subcommands of the linkevents_archive management command. I've also successfully ran the dump command against a database snapshot.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
