### PR TITLE
contiuously process oldest monthly aggregates

### DIFF
--- a/extlinks/aggregates/cron.py
+++ b/extlinks/aggregates/cron.py
@@ -1,6 +1,6 @@
 from django_cron import CronJobBase, Schedule
 
-from django.core.management import call_command
+from subprocess import check_output
 
 
 class LinkAggregatesCron(CronJobBase):
@@ -13,7 +13,8 @@ class LinkAggregatesCron(CronJobBase):
     code = "aggregates.link_aggregates_cron"
 
     def do(self):
-        call_command("fill_link_aggregates")
+        return check_output(["python", "manage.py", "fill_link_aggregates"], text=True)
+
 
 class MonthlyLinkAggregatesCron(CronJobBase):
     """
@@ -35,7 +36,10 @@ class MonthlyLinkAggregatesCron(CronJobBase):
     code = "aggregates.monthly_link_aggregates_cron"
 
     def do(self):
-        call_command("fill_monthly_link_aggregates")
+        return check_output(
+            ["python", "manage.py", "fill_monthly_link_aggregates"], text=True
+        )
+
 
 class UserAggregatesCron(CronJobBase):
     RETRY_AFTER_FAILURE_MINS = 360
@@ -47,7 +51,8 @@ class UserAggregatesCron(CronJobBase):
     code = "aggregates.user_aggregates_cron"
 
     def do(self):
-        call_command("fill_user_aggregates")
+        return check_output(["python", "manage.py", "fill_user_aggregates"], text=True)
+
 
 class MonthlyUserAggregatesCron(CronJobBase):
     """
@@ -69,7 +74,10 @@ class MonthlyUserAggregatesCron(CronJobBase):
     code = "aggregates.monthly_user_aggregates_cron"
 
     def do(self):
-        call_command("fill_monthly_user_aggregates")
+        return check_output(
+            ["python", "manage.py", "fill_monthly_user_aggregates"], text=True
+        )
+
 
 class PageProjectAggregatesCron(CronJobBase):
     RETRY_AFTER_FAILURE_MINS = 360
@@ -81,7 +89,10 @@ class PageProjectAggregatesCron(CronJobBase):
     code = "aggregates.pageproject_aggregates_cron"
 
     def do(self):
-        call_command("fill_pageproject_aggregates")
+        return check_output(
+            ["python", "manage.py", "fill_pageproject_aggregates"], text=True
+        )
+
 
 class MonthlyPageProjectAggregatesCron(CronJobBase):
     """
@@ -103,4 +114,6 @@ class MonthlyPageProjectAggregatesCron(CronJobBase):
     code = "aggregates.monthly_pageproject_aggregates_cron"
 
     def do(self):
-        call_command("fill_monthly_pageproject_aggregates")
+        return check_output(
+            ["python", "manage.py", "fill_monthly_pageproject_aggregates"], text=True
+        )

--- a/extlinks/aggregates/cron.py
+++ b/extlinks/aggregates/cron.py
@@ -27,10 +27,9 @@ class MonthlyLinkAggregatesCron(CronJobBase):
 
     RETRY_AFTER_FAILURE_MINS = 360
     MIN_NUM_FAILURES = 5
-    # Will run monthly on the 3rd day at 01:00 UTC
+    # Will run every 5 minutes
     schedule = Schedule(
-        run_at_times=["01:00"],
-        run_on_days=[10],
+        run_every_mins=5,
         retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS,
     )
     code = "aggregates.monthly_link_aggregates_cron"
@@ -65,10 +64,9 @@ class MonthlyUserAggregatesCron(CronJobBase):
 
     RETRY_AFTER_FAILURE_MINS = 360
     MIN_NUM_FAILURES = 5
-    # Will run monthly on the 3rd day at 01:30 UTC
+    # Will run every 5 minutes
     schedule = Schedule(
-        run_at_times=["01:30"],
-        run_on_days=[10],
+        run_every_mins=5,
         retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS,
     )
     code = "aggregates.monthly_user_aggregates_cron"
@@ -105,10 +103,9 @@ class MonthlyPageProjectAggregatesCron(CronJobBase):
 
     RETRY_AFTER_FAILURE_MINS = 360
     MIN_NUM_FAILURES = 5
-    # Will run monthly on the 3rd day at 03:30 UTC
+    # Will run every 5 minutes
     schedule = Schedule(
-        run_at_times=["03:30"],
-        run_on_days=[10],
+        run_every_mins=5,
         retry_after_failure_mins=RETRY_AFTER_FAILURE_MINS,
     )
     code = "aggregates.monthly_pageproject_aggregates_cron"

--- a/extlinks/aggregates/management/commands/fill_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_link_aggregates.py
@@ -116,7 +116,8 @@ class Command(BaseCommand):
         url_patterns = collection.get_url_patterns()
         for url_pattern in url_patterns:
             link_events_with_annotated_timestamp = url_pattern.link_events.annotate(
-                timestamp_date=Cast("timestamp", DateField())).distinct()
+                timestamp_date=Cast("timestamp", DateField())
+            ).distinct()
             link_events = (
                 link_events_with_annotated_timestamp.values(
                     "timestamp_date", "on_user_list"
@@ -160,12 +161,16 @@ class Command(BaseCommand):
             # Granulation level for the daily aggregation.
             # Changing this filter should also impact the monthly
             # aggregation in `fill_monthly_link_aggregates.py`
-            existing_link_aggregate = LinkAggregate.objects.filter(
-                organisation=collection.organisation,
-                collection=collection,
-                full_date=link_event["timestamp_date"],
-                on_user_list=link_event["on_user_list"],
-            ).exclude(day=0).first()
+            existing_link_aggregate = (
+                LinkAggregate.objects.filter(
+                    organisation=collection.organisation,
+                    collection=collection,
+                    full_date=link_event["timestamp_date"],
+                    on_user_list=link_event["on_user_list"],
+                )
+                .exclude(day=0)
+                .first()
+            )
             if existing_link_aggregate is not None:
                 if (
                     existing_link_aggregate.total_links_added

--- a/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
@@ -65,8 +65,9 @@ class Command(BaseCommand):
                 )
         else:
             today = date.today()
-            oldest_agg = LinkAggregate.objects.exclude(day=0).earliest("full_date")
-            if oldest_agg is None:
+            try:
+                oldest_agg = LinkAggregate.objects.exclude(day=0).earliest("full_date")
+            except LinkAggregate.DoesNotExist:
                 self.info("No data to process.")
                 return
             oldest_date = oldest_agg.full_date

--- a/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
@@ -1,3 +1,4 @@
+import calendar
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
 import logging
@@ -14,6 +15,13 @@ logger = logging.getLogger("django")
 
 class Command(BaseCommand):
     help = "Adds monthly aggregated data into the LinkAggregate table"
+
+    def info(self, msg):
+        # Log and print so that messages are visible
+        # in docker logs (log) and cron job logs (print)
+        logger.info(msg)
+        self.stdout.write(msg)
+        self.stdout.flush()
 
     def add_arguments(self, parser):
         # Option to filter by specific collection(s)
@@ -34,13 +42,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """
         Default execution of this job is to process all collections for
-        the past month.
+        the oldest month.
 
         Additional options are specified in `add_arguments` so you can
         run by specific collection, year/month, or a full scan of the
         historic data.
         """
-        logger.info("Monthly LinkAggregate job started")
+        self.info("Monthly LinkAggregate job started")
 
         if options["year_month"]:
             try:
@@ -57,10 +65,22 @@ class Command(BaseCommand):
                 )
         else:
             today = date.today()
-            last_day_of_month = today.replace(day=1) - timedelta(days=1)
-            first_day_of_month = last_day_of_month.replace(day=1)
+            oldest_agg = LinkAggregate.objects.exclude(day=0).earliest("full_date")
+            if oldest_agg is None:
+                self.info("No data to process.")
+                return
+            oldest_date = oldest_agg.full_date
+            monthrange = calendar.monthrange(oldest_date.year, oldest_date.month)
+            first_day_of_month = oldest_date.replace(day=1)
+            last_day_of_month = oldest_date.replace(day=monthrange[1])
+            no_later_than_date = today - timedelta(days=10)
+            if last_day_of_month > no_later_than_date:
+                self.info(
+                    f"No data within allowed date range: {no_later_than_date} falls within the month of {oldest_date}"
+                )
+                return
 
-        logger.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
+        self.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
         month_filter = Q(
             full_date__gte=first_day_of_month, full_date__lte=last_day_of_month
         )
@@ -71,7 +91,7 @@ class Command(BaseCommand):
         else:
             self._process_aggregation(month_filter)
 
-        logger.info("Monthly LinkAggregate job ended")
+        self.info("Monthly LinkAggregate job ended")
 
     def _process_aggregation(self, main_filter_query):
         """
@@ -92,7 +112,7 @@ class Command(BaseCommand):
         -------
         None
         """
-        logger.info("Fetching the main query")
+        self.info("Fetching the main query")
 
         aggregated_data = (
             LinkAggregate.objects.filter(main_filter_query)
@@ -117,11 +137,11 @@ class Command(BaseCommand):
         for batch_index, batch in enumerate(batch_iterator(aggregated_data), start=1):
             with transaction.atomic():
                 total_aggregations += len(batch)
-                logger.info(f"Processing batch {batch_index} (size: {len(batch)})")
+                self.info(f"Processing batch {batch_index} (size: {len(batch)})")
                 for monthly_aggregation in batch:
                     self._verify_and_save_aggregation(monthly_aggregation)
 
-        logger.info(f"Processed a total of {total_aggregations} monthly aggregations")
+        self.info(f"Processed a total of {total_aggregations} monthly aggregations")
 
     def _verify_and_save_aggregation(self, monthly_aggregation):
         """

--- a/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
@@ -66,10 +66,11 @@ class Command(BaseCommand):
                 )
         else:
             today = date.today()
-            oldest_agg = PageProjectAggregate.objects.exclude(day=0).earliest(
-                "full_date"
-            )
-            if oldest_agg is None:
+            try:
+                oldest_agg = PageProjectAggregate.objects.exclude(day=0).earliest(
+                    "full_date"
+                )
+            except PageProjectAggregate.DoesNotExist:
                 self.info("No data to process.")
                 return
             oldest_date = oldest_agg.full_date

--- a/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
@@ -1,3 +1,4 @@
+import calendar
 from datetime import date, timedelta, datetime
 from dateutil.relativedelta import relativedelta
 import logging
@@ -65,8 +66,22 @@ class Command(BaseCommand):
                 )
         else:
             today = date.today()
-            last_day_of_month = today.replace(day=1) - timedelta(days=1)
-            first_day_of_month = last_day_of_month.replace(day=1)
+            oldest_agg = PageProjectAggregate.objects.exclude(day=0).earliest(
+                "full_date"
+            )
+            if oldest_agg is None:
+                self.info("No data to process.")
+                return
+            oldest_date = oldest_agg.full_date
+            monthrange = calendar.monthrange(oldest_date.year, oldest_date.month)
+            first_day_of_month = oldest_date.replace(day=1)
+            last_day_of_month = oldest_date.replace(day=monthrange[1])
+            no_later_than_date = today - timedelta(days=10)
+            if last_day_of_month > no_later_than_date:
+                self.info(
+                    f"No data within allowed date range: {no_later_than_date} falls within the month of {oldest_date}"
+                )
+                return
 
         self.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
         month_filter = Q(

--- a/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
@@ -16,6 +16,13 @@ BATCH_SIZE = 500
 class Command(BaseCommand):
     help = "Adds monthly aggregated data into the PageProjectAggregate table"
 
+    def info(self, msg):
+        # Log and print so that messages are visible
+        # in docker logs (log) and cron job logs (print)
+        logger.info(msg)
+        self.stdout.write(msg)
+        self.stdout.flush()
+
     def add_arguments(self, parser):
         # Option to filter by specific collection(s)
         parser.add_argument(
@@ -41,7 +48,7 @@ class Command(BaseCommand):
         run by specific collection, year/month, or a full scan of the
         historic data.
         """
-        logger.info("Monthly PageProjectAggregate job started")
+        self.info("Monthly PageProjectAggregate job started")
 
         if options["year_month"]:
             try:
@@ -61,7 +68,7 @@ class Command(BaseCommand):
             last_day_of_month = today.replace(day=1) - timedelta(days=1)
             first_day_of_month = last_day_of_month.replace(day=1)
 
-        logger.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
+        self.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
         month_filter = Q(
             full_date__gte=first_day_of_month, full_date__lte=last_day_of_month
         )
@@ -72,7 +79,7 @@ class Command(BaseCommand):
         else:
             self._process_aggregation(month_filter)
 
-        logger.info("Monthly PageProjectAggregate job ended")
+        self.info("Monthly PageProjectAggregate job ended")
 
     def _process_aggregation(self, main_filter_query):
         """
@@ -94,7 +101,7 @@ class Command(BaseCommand):
         -------
         None
         """
-        logger.info("Fetching the main query")
+        self.info("Fetching the main query")
 
         aggregated_data = (
             PageProjectAggregate.objects.filter(main_filter_query)
@@ -123,11 +130,11 @@ class Command(BaseCommand):
         ):
             with transaction.atomic():
                 total_aggregations += len(batch)
-                logger.info(f"Processing batch {batch_index} (size: {len(batch)})")
+                self.info(f"Processing batch {batch_index} (size: {len(batch)})")
                 for monthly_aggregation in batch:
                     self._verify_and_save_aggregation(monthly_aggregation)
 
-        logger.info(f"Processed a total of {total_aggregations} monthly aggregations")
+        self.info(f"Processed a total of {total_aggregations} monthly aggregations")
 
     def _verify_and_save_aggregation(self, monthly_aggregation):
         """

--- a/extlinks/aggregates/management/commands/fill_monthly_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_user_aggregates.py
@@ -57,8 +57,9 @@ class Command(BaseCommand):
                 )
         else:
             today = date.today()
-            oldest_agg = UserAggregate.objects.exclude(day=0).earliest("full_date")
-            if oldest_agg is None:
+            try:
+                oldest_agg = UserAggregate.objects.exclude(day=0).earliest("full_date")
+            except UserAggregate.DoesNotExist:
                 self.info("No data to process.")
                 return
             oldest_date = oldest_agg.full_date

--- a/extlinks/aggregates/management/commands/fill_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_user_aggregates.py
@@ -163,25 +163,36 @@ class Command(BaseCommand):
             on_user_list = link_event["on_user_list"]
             links_added = link_event["links_added"]
             links_removed = link_event["links_removed"]
-            if any(attr is None for attr in [username, full_date, on_user_list, links_added, links_removed]):
+            if any(
+                attr is None
+                for attr in [
+                    username,
+                    full_date,
+                    on_user_list,
+                    links_added,
+                    links_removed,
+                ]
+            ):
                 continue
 
             # Granulation level for the daily aggregation.
             # Changing this filter should also impact the monthly
             # aggregation in `fill_monthly_user_aggregates.py`
-            existing_link_aggregate = UserAggregate.objects.filter(
-                organisation=collection.organisation,
-                collection=collection,
-                username=username,
-                full_date=full_date,
-                on_user_list=on_user_list,
-            ).exclude(day=0).first()
+            existing_link_aggregate = (
+                UserAggregate.objects.filter(
+                    organisation=collection.organisation,
+                    collection=collection,
+                    username=username,
+                    full_date=full_date,
+                    on_user_list=on_user_list,
+                )
+                .exclude(day=0)
+                .first()
+            )
             if existing_link_aggregate is not None:
                 if (
-                    existing_link_aggregate.total_links_added
-                    != links_added
-                    or existing_link_aggregate.total_links_removed
-                    != links_removed
+                    existing_link_aggregate.total_links_added != links_added
+                    or existing_link_aggregate.total_links_removed != links_removed
                 ):
                     # Updating the total links added and removed
                     existing_link_aggregate.total_links_added = links_added

--- a/extlinks/aggregates/tests.py
+++ b/extlinks/aggregates/tests.py
@@ -82,7 +82,7 @@ class LinkAggregateCommandTest(TestCase):
         self.assertEqual(LinkAggregate.objects.count(), 0)
         # Add LinkAggregates NOTE: the last LinkAggregate date here needs to be
         # greater than the latest LinkEvent date in the setUp
-        LinkAggregateFactory(full_date=date(2020, 1, 1))
+        LinkAggregateFactory(full_date=date(2020, 1, 11))
         LinkAggregateFactory(full_date=date(2020, 2, 12))
         LinkAggregateFactory(full_date=date(2020, 2, 15))
         LinkAggregateFactory(full_date=date(2020, 9, 10))
@@ -309,7 +309,7 @@ class UserAggregateCommandTest(TestCase):
         self.assertEqual(UserAggregate.objects.count(), 0)
         # Add UserAggregate. NOTE: the last UserAggregate.date here needs to be
         # greater than the latest LinkEvent date in the setUp
-        UserAggregateFactory(full_date=date(2020, 1, 1))
+        UserAggregateFactory(full_date=date(2020, 1, 11))
         UserAggregateFactory(full_date=date(2020, 2, 12))
         UserAggregateFactory(full_date=date(2020, 2, 15))
         UserAggregateFactory(full_date=date(2020, 9, 10))
@@ -566,7 +566,7 @@ class PageProjectAggregateCommandTest(TestCase):
         self.assertEqual(PageProjectAggregate.objects.count(), 0)
         # Add PageProjectAggregates NOTE: the last PageProjectAggregate date here needs to be
         # greater than the latest LinkEvent date in the setUp
-        PageProjectAggregateFactory(full_date=date(2020, 1, 1))
+        PageProjectAggregateFactory(full_date=date(2020, 1, 11))
         PageProjectAggregateFactory(full_date=date(2020, 2, 12))
         PageProjectAggregateFactory(full_date=date(2020, 2, 15))
         PageProjectAggregateFactory(full_date=date(2020, 9, 10))
@@ -743,7 +743,7 @@ class MonthlyLinkAggregateCommandTest(TestCase):
             )
 
     def test_aggregate_monthly_data(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             self.assertEqual(LinkAggregate.objects.filter(day=0).count(), 0)
 
             call_command("fill_monthly_link_aggregates")
@@ -759,7 +759,7 @@ class MonthlyLinkAggregateCommandTest(TestCase):
             )
 
     def test_no_aggregation_when_no_new_data(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_link_aggregates")
 
             # Running it again should NOT create duplicate entries
@@ -767,10 +767,10 @@ class MonthlyLinkAggregateCommandTest(TestCase):
             self.assertEqual(LinkAggregate.objects.filter(day=0).count(), 1)
 
     def test_aggregate_next_month(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_link_aggregates")
 
-        with time_machine.travel(date(2024, 3, 1)):
+        with time_machine.travel(date(2024, 3, 11)):
             # Simulate next month by adding 5 more days to the next month
             next_total_added = 0
             next_total_removed = 0
@@ -794,7 +794,7 @@ class MonthlyLinkAggregateCommandTest(TestCase):
             self.assertEqual(LinkAggregate.objects.exclude(day=0).count(), 0)
 
     def test_specific_collection_aggregation(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             other_collection = CollectionFactory(
                 name="Other Collection", organisation=self.organisation
             )
@@ -833,7 +833,7 @@ class MonthlyLinkAggregateCommandTest(TestCase):
                 total_links_removed=day - 1,
             )
 
-        with time_machine.travel(date(2024, 5, 1)):
+        with time_machine.travel(date(2024, 5, 11)):
             call_command("fill_monthly_link_aggregates", year_month="2024-01")
 
             self.assertEqual(LinkAggregate.objects.filter(day=0).count(), 1)
@@ -881,7 +881,7 @@ class MonthlyUserAggregateCommandTest(TestCase):
             )
 
     def test_aggregate_monthly_data(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             self.assertEqual(UserAggregate.objects.filter(day=0).count(), 0)
 
             call_command("fill_monthly_user_aggregates")
@@ -899,7 +899,7 @@ class MonthlyUserAggregateCommandTest(TestCase):
             )
 
     def test_no_aggregation_when_no_new_data(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_user_aggregates")
 
             # Running it again should NOT create duplicate entries
@@ -910,7 +910,7 @@ class MonthlyUserAggregateCommandTest(TestCase):
         """
         Simulating running the script again, in case we receive new data
         """
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_user_aggregates")
 
             # Adding more data to the same month should add up to the totals
@@ -943,10 +943,10 @@ class MonthlyUserAggregateCommandTest(TestCase):
             )
 
     def test_aggregate_next_month(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_user_aggregates")
 
-        with time_machine.travel(date(2024, 3, 1)):
+        with time_machine.travel(date(2024, 3, 11)):
             # Simulate next month by adding 5 more days to the next month
             next_total_added = 0
             next_total_removed = 0
@@ -973,7 +973,7 @@ class MonthlyUserAggregateCommandTest(TestCase):
             self.assertEqual(UserAggregate.objects.exclude(day=0).count(), 0)
 
     def test_specific_collection_aggregation(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             other_collection = CollectionFactory(
                 name="Other Collection", organisation=self.organisation
             )
@@ -1014,7 +1014,7 @@ class MonthlyUserAggregateCommandTest(TestCase):
                 total_links_removed=day - 1,
             )
 
-        with time_machine.travel(date(2024, 5, 1)):
+        with time_machine.travel(date(2024, 5, 11)):
             call_command("fill_monthly_user_aggregates", year_month="2024-01")
 
             self.assertEqual(UserAggregate.objects.filter(day=0).count(), 2)
@@ -1073,7 +1073,7 @@ class MonthlyPageProjectAggregateCommandTest(TestCase):
             )
 
     def test_aggregate_monthly_data(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             self.assertEqual(PageProjectAggregate.objects.filter(day=0).count(), 0)
 
             call_command("fill_monthly_pageproject_aggregates")
@@ -1095,7 +1095,7 @@ class MonthlyPageProjectAggregateCommandTest(TestCase):
             )
 
     def test_no_aggregation_when_no_new_data(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_pageproject_aggregates")
 
             # Running it again should NOT create duplicate entries
@@ -1106,7 +1106,7 @@ class MonthlyPageProjectAggregateCommandTest(TestCase):
         """
         Simulating running the script again, in case we receive new data
         """
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_pageproject_aggregates")
 
             # Adding more data to the same month should add up to the totals
@@ -1141,10 +1141,10 @@ class MonthlyPageProjectAggregateCommandTest(TestCase):
             )
 
     def test_aggregate_next_month(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             call_command("fill_monthly_pageproject_aggregates")
 
-        with time_machine.travel(date(2024, 3, 1)):
+        with time_machine.travel(date(2024, 3, 11)):
             # Simulate next month by adding 5 more days to the next month
             next_total_added = 0
             next_total_removed = 0
@@ -1176,7 +1176,7 @@ class MonthlyPageProjectAggregateCommandTest(TestCase):
             self.assertEqual(PageProjectAggregate.objects.exclude(day=0).count(), 0)
 
     def test_specific_collection_aggregation(self):
-        with time_machine.travel(date(2024, 2, 1)):
+        with time_machine.travel(date(2024, 2, 11)):
             other_collection = CollectionFactory(
                 name="Other Collection", organisation=self.organisation
             )
@@ -1221,7 +1221,7 @@ class MonthlyPageProjectAggregateCommandTest(TestCase):
                 total_links_removed=day - 1,
             )
 
-        with time_machine.travel(date(2024, 5, 1)):
+        with time_machine.travel(date(2024, 5, 11)):
             call_command("fill_monthly_pageproject_aggregates", year_month="2024-01")
 
             self.assertEqual(PageProjectAggregate.objects.filter(day=0).count(), 2)


### PR DESCRIPTION
## Description
- the commands will now process the oldest available month of aggregates by default
- it will not process data that falls within the last 10 days
- updates monthly aggregate crons to run every 5 minutes
- changes command logging and cron calls to commands to provide log info in django cron log objects

## Rationale
This change will allow us to process our backlog of monthly aggregates without intervention and with better logging.

## Phabricator Ticket
https://phabricator.wikimedia.org/T370977

## How Has This Been Tested?
I did manual local testing to verify; I updated existing tests to pass

## Screenshots of your changes (if appropriate):
Before logging change:
![image](https://github.com/user-attachments/assets/2d68e117-cc67-4b7e-a5e4-e6d3a6038caa)
After logging change:
![image](https://github.com/user-attachments/assets/0aaea83e-44bf-4bbf-8325-d6583fbd5aae)


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
