### PR TITLE
Increase time and size of mysql server variables

### DIFF
--- a/db.cnf
+++ b/db.cnf
@@ -2,7 +2,8 @@
 collation-server = utf8mb4_unicode_ci
 init-connect = SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci
 character-set-server = utf8mb4
-max_allowed_packet=768M
+max_allowed_packet=1024M
 connect_timeout = 1200
 net_read_timeout = 180
 innodb_buffer_pool_size = 512M
+

--- a/db.cnf
+++ b/db.cnf
@@ -2,8 +2,7 @@
 collation-server = utf8mb4_unicode_ci
 init-connect = SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci
 character-set-server = utf8mb4
-max_allowed_packet=512M
-connect_timeout = 60
+max_allowed_packet=768M
+connect_timeout = 1200
 net_read_timeout = 180
 innodb_buffer_pool_size = 512M
-


### PR DESCRIPTION
Variables that were increased:

- max_allowed_packet
- connect_timeout

Change-Id: I983b96b4260f10d08f95027254233a16447a6d30

## Description
Describe your changes in detail following the [commit message guidelines]
Increase time on mysql server variables due to mysql errors. 

## Rationale

Hopefully fixes (2006, 'MySQL server has gone away') issue we are seeing in production when running cron jobs. 

## Phabricator Ticket
No ticket

## How Has This Been Tested?

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
