### PR TITLE
New script for running linkevents_archive for a range of dates

### DIFF
--- a/extlinks/links/management/commands/linkevents_dump_range.py
+++ b/extlinks/links/management/commands/linkevents_dump_range.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand
+from django.core.management import call_command
+from datetime import datetime, timedelta
+
+
+class Command(BaseCommand):
+    help = "Dump data for a range of dates"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--start", type=str, help="Start date (YYYY-MM-DD)", required=True
+        )
+        parser.add_argument(
+            "--end", type=str, help="End date (YYYY-MM-DD)", required=True
+        )
+        parser.add_argument("--output", type=str, help="Output prefix", required=True)
+
+    def handle(self, *args, **options):
+        start_date = datetime.strptime(options["start"], "%Y-%m-%d")
+        end_date = datetime.strptime(options["end"], "%Y-%m-%d")
+        output = options["output"]
+
+        current_date = start_date
+        while current_date <= end_date:
+            date_str = current_date.strftime("%Y-%m-%d")
+            self.stdout.write(f"Calling linkevents_archive for date: {date_str}...")
+
+            # Call the existing dump command within Django
+            call_command("linkevents_archive", "dump", date=current_date, output=output)
+
+            current_date += timedelta(days=1)
+
+        self.stdout.write(self.style.SUCCESS("All dumps completed!"))


### PR DESCRIPTION
## Description

Opening this as a draft pull request for now.

This is a very simple script that runs the command `linkevents_archive` multiple times for a range of dates. It is used for completing the task https://phabricator.wikimedia.org/T387887, and may not be necessary to merge this into production considering this is a one-time run script.

## Rationale
The process for migrating the old archives' schema is basically:
1. load the old archive (calling linkevents_archive on load mode)
2. perform the migration script of the version `0014` to fill the two new fields (content_type and object_id) - in `links/migrations/0014_migrate_url_pattern_relationships.py`
3. dump the loaded archive (calling linkevents_archive on dump mode)

Particularly on this 3rd step, this dump mode only accepts a specific date. To facilitate the execution of multiple dates, this script in this PR was created.

## Phabricator Ticket
https://phabricator.wikimedia.org/T387887

## How Has This Been Tested?
This new script can be manually tested by running:
```
python manage.py linkevents_dump_range --start=2019-07-01 --end=2019-07-31 --output=migrated_archive
```
And by observing the outputs, you can see how it just calls `linkevents_archive` (in dump mode) multiple times.

## Screenshots of your changes (if appropriate):
n/a

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
