### PR TITLE
Add close_old_connections function to most crons

### DIFF
--- a/extlinks/aggregates/management/commands/fill_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_link_aggregates.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta, datetime
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.models import Count, Q
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
@@ -45,6 +45,8 @@ class Command(BaseCommand):
 
             for collection in collections:
                 self._process_single_collection(link_event_filter, collection)
+
+        close_old_connections()
 
     def _get_linkevent_filter(self, collection=None):
         """

--- a/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.models import Count, Q, Sum
 
 from ...models import LinkAggregate
@@ -93,6 +93,7 @@ class Command(BaseCommand):
             self._process_aggregation(month_filter)
 
         self.info("Monthly LinkAggregate job ended")
+        close_old_connections()
 
     def _process_aggregation(self, main_filter_query):
         """

--- a/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_pageproject_aggregates.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.models import Count, Q, Sum
 
 from ...models import PageProjectAggregate
@@ -96,6 +96,7 @@ class Command(BaseCommand):
             self._process_aggregation(month_filter)
 
         self.info("Monthly PageProjectAggregate job ended")
+        close_old_connections()
 
     def _process_aggregation(self, main_filter_query):
         """

--- a/extlinks/aggregates/management/commands/fill_monthly_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_user_aggregates.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.models import Count, Q, Sum
 
 from ...models import UserAggregate
@@ -85,6 +85,7 @@ class Command(BaseCommand):
             self._process_aggregation(month_filter)
 
         self.info("Monthly UserAggregate job ended")
+        close_old_connections()
 
     def _process_aggregation(self, main_filter_query):
         """

--- a/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_pageproject_aggregates.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta, datetime
 import logging
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.models import Count, Q
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
@@ -48,6 +48,7 @@ class Command(BaseCommand):
 
             for collection in collections:
                 self._process_single_collection(link_event_filter, collection)
+        close_old_connections()
 
     def _get_linkevent_filter(self, collection=None):
         """

--- a/extlinks/aggregates/management/commands/fill_user_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_user_aggregates.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta, datetime
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction
+from django.db import transaction, close_old_connections
 from django.db.models import Count, Q
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
@@ -45,6 +45,8 @@ class Command(BaseCommand):
 
             for collection in collections:
                 self._process_single_collection(link_event_filter, collection)
+
+        close_old_connections()
 
     def _get_linkevent_filter(self, collection=None):
         """

--- a/extlinks/aggregates/tests.py
+++ b/extlinks/aggregates/tests.py
@@ -2,7 +2,7 @@ from datetime import datetime, date, timedelta, timezone
 import time_machine
 
 from django.core.management import call_command, CommandError
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from .factories import (
     LinkAggregateFactory,
@@ -19,7 +19,7 @@ from extlinks.organisations.factories import (
 from extlinks.organisations.models import Organisation
 
 
-class LinkAggregateCommandTest(TestCase):
+class LinkAggregateCommandTest(TransactionTestCase):
     def setUp(self):
         # Creating one Collection
         self.organisation = OrganisationFactory(name="ACME Org")
@@ -217,7 +217,7 @@ class LinkAggregateCommandTest(TestCase):
             call_command("fill_link_aggregates", collections=[new_collection.pk])
 
 
-class UserAggregateCommandTest(TestCase):
+class UserAggregateCommandTest(TransactionTestCase):
     def setUp(self):
         # Creating one Collection
         self.organisation = OrganisationFactory(name="ACME Org")
@@ -465,7 +465,7 @@ class UserAggregateCommandTest(TestCase):
             call_command("fill_user_aggregates", collections=[new_collection.pk])
 
 
-class PageProjectAggregateCommandTest(TestCase):
+class PageProjectAggregateCommandTest(TransactionTestCase):
     def setUp(self):
         # Creating one Collection
         self.organisation = OrganisationFactory(name="ACME Org")
@@ -723,7 +723,7 @@ class PageProjectAggregateCommandTest(TestCase):
             call_command("fill_pageproject_aggregates", collections=[new_collection.pk])
 
 
-class MonthlyLinkAggregateCommandTest(TestCase):
+class MonthlyLinkAggregateCommandTest(TransactionTestCase):
     def setUp(self):
         self.organisation = OrganisationFactory(name="ACME Org")
         self.collection = CollectionFactory(name="ACME", organisation=self.organisation)
@@ -847,7 +847,7 @@ class MonthlyLinkAggregateCommandTest(TestCase):
             )
 
 
-class MonthlyUserAggregateCommandTest(TestCase):
+class MonthlyUserAggregateCommandTest(TransactionTestCase):
     def setUp(self):
         self.organisation = OrganisationFactory(name="ACME Org")
         self.collection = CollectionFactory(name="ACME", organisation=self.organisation)
@@ -1035,7 +1035,7 @@ class MonthlyUserAggregateCommandTest(TestCase):
             )
 
 
-class MonthlyPageProjectAggregateCommandTest(TestCase):
+class MonthlyPageProjectAggregateCommandTest(TransactionTestCase):
     def setUp(self):
         self.organisation = OrganisationFactory(name="ACME Org")
         self.collection = CollectionFactory(name="ACME", organisation=self.organisation)

--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 
 from django.core import serializers
 from django.core.management import BaseCommand, call_command
-from django.db import connection
+from django.db import close_old_connections
 from django.db.models import Q, Max
 from django_cron.models import CronJobLog
 
@@ -124,7 +124,6 @@ class Command(BaseCommand):
             delete_query_set = query_set[:CHUNK_SIZE].values_list("id", flat=True)
             LinkEvent.objects.filter(pk__in=list(delete_query_set)).delete()
 
-
     def load(self, filenames: List[str]):
         """
         Import LinkEvents from gzipped JSON files.
@@ -174,3 +173,4 @@ class Command(BaseCommand):
             self.dump(date=options["date"], output=options["output"])
         if action == "load":
             self.load(filenames=options["filenames"])
+        close_old_connections()

--- a/extlinks/links/management/commands/linksearchtotal_collect.py
+++ b/extlinks/links/management/commands/linksearchtotal_collect.py
@@ -3,6 +3,7 @@ import MySQLdb
 import os
 
 from django.core.management import BaseCommand
+from django.db import close_old_connections
 
 from extlinks.links.helpers import split_url_for_query
 from extlinks.links.models import LinkSearchTotal, URLPattern
@@ -65,3 +66,5 @@ class Command(BaseCommand):
                 url=URLPattern.objects.get(pk=urlpattern_pk), total=total_count
             )
             linksearch_object.save()
+
+        close_old_connections()

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -3,7 +3,7 @@ import tempfile, glob, os
 from datetime import datetime, date, timezone
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, TransactionTestCase
 from django_cron.models import CronJobLog
 
 from extlinks.aggregates.models import (
@@ -270,7 +270,7 @@ class LinkEventsCollectCommandTest(TestCase):
         self.assertEqual(LinkEvent.objects.count(), 2)
 
 
-class LinkEventsArchiveCommandTest(TestCase):
+class LinkEventsArchiveCommandTest(TransactionTestCase):
     def setUp(self):
         self.user = UserFactory(username="jonsnow")
 
@@ -330,11 +330,17 @@ class LinkEventsArchiveCommandTest(TestCase):
             )
 
             # Ensure the expected archives were generated.
-            jan_16_archive = os.path.join(temp_dir, "links_linkevent_20210116_0.json.gz")
+            jan_16_archive = os.path.join(
+                temp_dir, "links_linkevent_20210116_0.json.gz"
+            )
             self.assertTrue(os.path.isfile(jan_16_archive))
-            jan_17_archive = os.path.join(temp_dir, "links_linkevent_20210117_0.json.gz")
+            jan_17_archive = os.path.join(
+                temp_dir, "links_linkevent_20210117_0.json.gz"
+            )
             self.assertTrue(os.path.isfile(jan_17_archive))
-            jan_18_archive = os.path.join(temp_dir, "links_linkevent_20210118_0.json.gz")
+            jan_18_archive = os.path.join(
+                temp_dir, "links_linkevent_20210118_0.json.gz"
+            )
             self.assertTrue(os.path.isfile(jan_18_archive))
 
             # Make sure the events that were archived got removed from the db.
@@ -412,9 +418,13 @@ class LinkEventsArchiveCommandTest(TestCase):
             call_command("linkevents_archive", "dump", output=temp_dir)
 
             # Ensure the expected archives were generated.
-            jan_16_archive = os.path.join(temp_dir, "links_linkevent_20250116_0.json.gz")
+            jan_16_archive = os.path.join(
+                temp_dir, "links_linkevent_20250116_0.json.gz"
+            )
             self.assertTrue(os.path.isfile(jan_16_archive))
-            jan_17_archive = os.path.join(temp_dir, "links_linkevent_20250117_0.json.gz")
+            jan_17_archive = os.path.join(
+                temp_dir, "links_linkevent_20250117_0.json.gz"
+            )
             self.assertTrue(os.path.isfile(jan_17_archive))
 
             # Make sure the events that were archived got removed from the db.
@@ -477,9 +487,13 @@ class LinkEventsArchiveCommandTest(TestCase):
             call_command("linkevents_archive", "dump", output=temp_dir)
 
             # Ensure that no archives were generated.
-            jan_16_archive = os.path.join(temp_dir, "links_linkevent_20250116_0.json.gz")
+            jan_16_archive = os.path.join(
+                temp_dir, "links_linkevent_20250116_0.json.gz"
+            )
             self.assertFalse(os.path.isfile(jan_16_archive))
-            jan_17_archive = os.path.join(temp_dir, "links_linkevent_20250117_0.json.gz")
+            jan_17_archive = os.path.join(
+                temp_dir, "links_linkevent_20250117_0.json.gz"
+            )
             self.assertFalse(os.path.isfile(jan_17_archive))
 
             # Ensure that no LinkEvents were deleted.
@@ -526,9 +540,13 @@ class LinkEventsArchiveCommandTest(TestCase):
             call_command("linkevents_archive", "dump", output=temp_dir)
 
             # Ensure that no archives were generated.
-            jan_16_archive = os.path.join(temp_dir, "links_linkevent_20250116_0.json.gz")
+            jan_16_archive = os.path.join(
+                temp_dir, "links_linkevent_20250116_0.json.gz"
+            )
             self.assertFalse(os.path.isfile(jan_16_archive))
-            jan_17_archive = os.path.join(temp_dir, "links_linkevent_20250117_0.json.gz")
+            jan_17_archive = os.path.join(
+                temp_dir, "links_linkevent_20250117_0.json.gz"
+            )
             self.assertFalse(os.path.isfile(jan_17_archive))
 
             # Ensure that no LinkEvents were deleted.
@@ -587,7 +605,7 @@ class LinkEventsArchiveCommandTest(TestCase):
                 os.remove(file)
 
 
-class EZProxyRemovalCommandTest(TestCase):
+class EZProxyRemovalCommandTest(TransactionTestCase):
     def setUp(self):
         self.user = UserFactory(username="jonsnow")
 
@@ -694,7 +712,7 @@ class EZProxyRemovalCommandTest(TestCase):
         self.assertEqual(PageProjectAggregate.objects.count(), 2)
 
 
-class FixOnUserListCommandTest(TestCase):
+class FixOnUserListCommandTest(TransactionTestCase):
     def setUp(self):
         self.user1 = UserFactory(username="jonsnow")
 

--- a/extlinks/organisations/management/commands/users_update_lists.py
+++ b/extlinks/organisations/management/commands/users_update_lists.py
@@ -2,6 +2,7 @@ import os
 import requests
 
 from django.core.management import BaseCommand
+from django.db import close_old_connections
 
 from extlinks.organisations.models import Organisation, User
 
@@ -35,3 +36,5 @@ class Command(BaseCommand):
                 user_object, _ = User.objects.get_or_create(username=username)
 
                 organisation.username_list.add(user_object)
+
+        close_old_connections()

--- a/extlinks/organisations/tests.py
+++ b/extlinks/organisations/tests.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 import json
 
 from django.core.management import call_command
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, TransactionTestCase
 from django.urls import reverse
 
 from extlinks.common.views import (
@@ -26,7 +26,7 @@ class OrganisationListTest(TestCase):
     def test_organisation_list_view(self):
         """
         Test that we can simply load the organisation list page successfully
-       """
+        """
         factory = RequestFactory()
 
         request = factory.get(reverse("organisations:list"))
@@ -48,7 +48,7 @@ class OrganisationListTest(TestCase):
         self.assertContains(response, self.organisation_two.name)
 
 
-class OrganisationDetailTest(TestCase):
+class OrganisationDetailTest(TransactionTestCase):
     """
     Mostly the same tests as for programs, at least for now.
     """

--- a/extlinks/programs/tests.py
+++ b/extlinks/programs/tests.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 import json
 
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, TransactionTestCase
 from django.urls import reverse
 from django.core.management import call_command
 
@@ -54,7 +54,7 @@ class ProgramListTest(TestCase):
         self.assertContains(response, self.program_two.name)
 
 
-class ProgramDetailTest(TestCase):
+class ProgramDetailTest(TransactionTestCase):
     def setUp(self):
         self.program1 = ProgramFactory()
         self.organisation1 = OrganisationFactory(name="Org 1", program=(self.program1,))


### PR DESCRIPTION
## Description
Add the `close_old_connections` function to most crons.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
We have observed several lingering stale DB connections whenever there are multiple errors in the crown jobs. This hopes to solve it.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)
Changed the tests and manual testing.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
