### PR TITLE
Decrease time django-cron logs are kept to 90 days

### DIFF
--- a/extlinks/settings/base.py
+++ b/extlinks/settings/base.py
@@ -29,7 +29,7 @@ INSTALLED_APPS = [
     "extlinks.programs",
     "django_cron",
     "extlinks.aggregates",
-    "django_extensions"
+    "django_extensions",
 ]
 
 # Fixing django_cron migration warning
@@ -157,7 +157,7 @@ CRON_CLASSES = [
     "extlinks.aggregates.cron.MonthlyUserAggregatesCron",
     "extlinks.aggregates.cron.MonthlyPageProjectAggregatesCron",
 ]
-# DJANGO_CRON_DELETE_LOGS_OLDER_THAN = 365  # Leave only this year's logs
+# DJANGO_CRON_DELETE_LOGS_OLDER_THAN = 90  # Leave only the last 3 month's logs
 
 # EMAIL CONFIGURATION
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Decrease the time django-cron logs are kept to 90 days.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Before, we had more errors in our cron jobs, so we had to keep a larger historical record. Since we will be running more crons daily and more efficiently, it is better to have less historical data so the table size remains small.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
