### PR TITLE
Check aggregate tables over cron logs for archive date

### DIFF
--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -395,28 +395,41 @@ class LinkEventsArchiveCommandTest(TransactionTestCase):
                 username=self.user,
             )
 
-        # Add cron job log entries since these are needed to automatically
+        # Add aggregate entries since these are needed to automatically
         # determine safe dates for the job to filter by.
 
-        CronJobLog(
-            code="aggregates.link_aggregates_cron",
-            start_time=datetime(2025, 1, 18, 18, 0, 0),
-            end_time=datetime(2025, 1, 18, 18, 0, 0),
-            is_success=True,
+        LinkAggregate(
+            organisation=self.jstor_organisation,
+            collection=self.jstor_collection,
+            day=18,
+            month=1,
+            year=2025,
+            full_date=date(2025, 1, 18),
+            total_links_added=10,
+            total_links_removed=5,
         ).save()
-
-        CronJobLog(
-            code="aggregates.user_aggregates_cron",
-            start_time=datetime(2025, 1, 18, 19, 0, 0),
-            end_time=datetime(2025, 1, 18, 19, 0, 0),
-            is_success=True,
+        UserAggregate(
+            organisation=self.jstor_organisation,
+            collection=self.jstor_collection,
+            username=self.user.username,
+            day=19,
+            month=1,
+            year=2025,
+            full_date=date(2025, 1, 19),
+            total_links_added=10,
+            total_links_removed=5,
         ).save()
-
-        CronJobLog(
-            code="aggregates.pageproject_aggregates_cron",
-            start_time=datetime(2025, 1, 18, 20, 0, 0),
-            end_time=datetime(2025, 1, 18, 20, 0, 0),
-            is_success=True,
+        PageProjectAggregate(
+            organisation=self.jstor_organisation,
+            collection=self.jstor_collection,
+            project_name="Project",
+            page_name="Page",
+            day=20,
+            month=1,
+            year=2025,
+            full_date=date(2025, 1, 20),
+            total_links_added=10,
+            total_links_removed=5,
         ).save()
 
         temp_dir = tempfile.gettempdir()


### PR DESCRIPTION
## Description

Changes `linkevents_archive` so that if the date is unspecified it checks the aggregates tables to know what links are safe to archive instead of the cron job logs.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

The cron job logs have proven to be an unreliable way of knowing when aggregates complete, so we need to check data in the aggregate tables instead.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

https://phabricator.wikimedia.org/T370896

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

Existing tests cover this.

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
