### PR TITLE
Add 'coverage' and updated README with instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ static/debug_toolbar
 static/django_extensions
 
 db.json
+
+.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ After cloning the repository to your directory of choice:
 
 You should now be able to access the tool via `localhost`.
 
+## Running tests
+
+The tests can be run within the container using docker exec. The following command will run the test suite:
+
+```bash
+docker exec -ti externallinks-externallinks-1 python manage.py test
+```
+
+If you would like to generate a coverage report as well, you can invoke the test runner using `coverage run` instead:
+
+```bash
+docker exec -ti externallinks-externallinks-1 coverage run manage.py test
+```
+
+You can view this report in your browser (located at `htmlcov/index.html`) by running the following command:
+
+```bash
+docker exec -ti externallinks-externallinks-1 coverage html
+```
+
 ## Swift object store - local setup (separate container)
 
 IMPORTANT: This setup should NOT be used in production! It is only suitable for local testing.

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -11,3 +11,4 @@ sseclient==0.0.27
 time_machine==2.14.2
 python-swiftclient>=4.6.0,<5.0.0
 keystoneauth1>=5.9.2,<6.0.0
+coverage==7.8.0


### PR DESCRIPTION
## Description

This patch adds [coverage](https://pypi.org/project/coverage/) to the project and updates the README with instructions on how to generate coverage reports. Coverage data can be generated by running `coverage run manage.py test`, and an HTML report can be generated with `coverage html` which gets written to `htmlcov/index.html`.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

The test suite is lacking in many areas such as views and having coverage reporting setup in the project would help us increase our test coverage.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

[T392250](https://phabricator.wikimedia.org/T392250)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

N/A

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
