### PR TITLE
Fix indentation on file upload to be nested within the `with` block s…

### DIFF
--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -297,12 +297,12 @@ class Command(BaseCommand):
                         f"Failed to locate {local_filepath} in Swift container {container_name}"
                     )
                     pass
-            conn.put_object(
-                container_name,
-                remote_filename,
-                contents=f,
-                content_type="application/gzip",
-            )
+                conn.put_object(
+                    container_name,
+                    remote_filename,
+                    contents=f,
+                    content_type="application/gzip",
+                )
             self.log_msg(
                 f"Successfully uploaded {local_filepath} to Swift container {container_name}"
             )


### PR DESCRIPTION
…o that we can upload a file before it's closed.

Change-Id: I4eea62592861cff3ef9427fe0e0284fcc440861b

## Description
(https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)
Ensure that we haven't closed the file before we attempt to upload it. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
Indentation issue 

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?

- Archive linkevents using the linkevents_archive management command.
- Insure you have archived files in your ./backup directory.
- Run the command:

`python manage.py upload_all_archived_linkevents --dir "./backup"`

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
