### PR TITLE
Added program total management commands to crontab

### DIFF
--- a/crontab
+++ b/crontab
@@ -24,6 +24,9 @@ PATH=/app/bin:/usr/bin:/bin
 0	3	*	*	*	root	python manage.py fill_monthly_link_aggregates
 10	3	*	*	*	root	python manage.py fill_monthly_user_aggregates
 50	3	*	*	*	root	python manage.py fill_monthly_pageproject_aggregates
+0	4	*	*	*	root	python manage.py fill_top_organisations_totals
+10	4	*	*	*	root	python manage.py fill_top_projects_totals
+20	4	*	*	*	root	python manage.py fill_top_users_totals
 # from extlinks/links/cron.py
 # weekly
 10	5	*	*	1	root	python manage.py linksearchtotal_collect
@@ -32,4 +35,3 @@ PATH=/app/bin:/usr/bin:/bin
 # from extlinks/organisations/cron.py
 # hourly (was every 65 minutes for some reason?)
 5	*	*	*	*	root	python manage.py users_update_lists
-


### PR DESCRIPTION
## Description

The crontab has been updated to call the program total fill commands for all aggregate types. These program total commands run daily.

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

The crontab hasn't been updated to call the new program total commands yet.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

[T396681](https://phabricator.wikimedia.org/T396681)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

Manually

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

N/A

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)