### PR TITLE
Add try/except clauses in aggregates archive and swift.py

### DIFF
--- a/crontab
+++ b/crontab
@@ -24,9 +24,9 @@ PATH=/app/bin:/usr/bin:/bin
 0	3	*	*	*	root	python manage.py fill_monthly_link_aggregates
 10	3	*	*	*	root	python manage.py fill_monthly_user_aggregates
 50	3	*	*	*	root	python manage.py fill_monthly_pageproject_aggregates
-0	5	10	*	*	root	python manage.py archive_link_aggregates dump
-10	5	10	*	*	root	python manage.py archive_user_aggregates dump
-20	5	10	*	*	root	python manage.py archive_pageproject_aggregates dump
+0	5	10	*	*	root	python manage.py archive_link_aggregates dump --container archive-aggregates
+10	5	10	*	*	root	python manage.py archive_user_aggregates dump --container archive-aggregates
+20	5	10	*	*	root	python manage.py archive_pageproject_aggregates dump --container archive-aggregates
 # from extlinks/links/cron.py
 # weekly
 10	5	*	*	1	root	python manage.py linksearchtotal_collect

--- a/extlinks/aggregates/management/helpers/aggregate_archive_command.py
+++ b/extlinks/aggregates/management/helpers/aggregate_archive_command.py
@@ -246,7 +246,12 @@ class AggregateArchiveCommand(ABC, BaseCommand):
 
         logger.info("Uploading %d archives to object storage", len(filenames))
 
-        conn = swift.swift_connection()
+        try:
+            conn = swift.swift_connection()
+        except RuntimeError:
+            self.log_msg("Swift credentials not provided. Skipping upload.")
+            return False
+
         swift.ensure_container_exists(conn, container)
         successful, failed = swift.batch_upload_files(conn, container, filenames)
 

--- a/extlinks/common/swift.py
+++ b/extlinks/common/swift.py
@@ -60,8 +60,11 @@ def get_containers(conn: swiftclient.Connection) -> List[dict]:
     List[dict]
         A list of dictionaries containing information about each container.
     """
-
-    response = conn.get_account()
+    try:
+        response = conn.get_account()
+    except RuntimeError:
+        logger.error("Swift credentials not provided. Skipping upload.")
+        return False
     if not response or len(response) < 2:
         raise RuntimeError("Failed to retrieve container list from Swift account.")
 


### PR DESCRIPTION
## Description
- Explicitly stated the container name for every archive aggregate command
- Added try/except clauses in several parts of the code

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
- The container default is archive-linkevents. By separating the archived aggregates in a new container, we will have more order in our Object Storage.
- The try/except will help the archive command not error out.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
