### PR TITLE
Add a SWIFT_CONTAINER_AGGREGATES env variable

### DIFF
--- a/extlinks/aggregates/management/helpers/aggregate_archive_command.py
+++ b/extlinks/aggregates/management/helpers/aggregate_archive_command.py
@@ -202,7 +202,7 @@ class AggregateArchiveCommand(ABC, BaseCommand):
                 end = (datetime.date.today() - relativedelta(years=1)).replace(day=1)
 
         if not container:
-            container = os.environ.get("SWIFT_CONTAINER_NAME")
+            container = os.environ.get("SWIFT_CONTAINER_AGGREGATES")
 
         if end:
             cursor = start
@@ -280,7 +280,9 @@ class AggregateArchiveCommand(ABC, BaseCommand):
         try:
             conn = swift.swift_connection()
         except RuntimeError:
-            self.log_msg("Swift credentials not provided. Skipping upload.", level="error")
+            self.log_msg(
+                "Swift credentials not provided. Skipping upload.", level="error"
+            )
             return False
 
         try:

--- a/extlinks/links/management/commands/linkevents_archive.py
+++ b/extlinks/links/management/commands/linkevents_archive.py
@@ -20,9 +20,7 @@ from extlinks.aggregates.models import (
 logger = logging.getLogger("django")
 
 CHUNK_SIZE = 10_000
-SWIFT_CONTAINER_NAME = os.environ.get(
-    "SWIFT_CONTAINER_LINKEVENTS_ARCHIVE", "archive-linkevents"
-)
+SWIFT_CONTAINER_NAME = os.environ.get("SWIFT_CONTAINER_NAME", "archive-linkevents")
 
 
 class Command(BaseCommand):

--- a/template.env
+++ b/template.env
@@ -19,6 +19,7 @@ HOST_BACKUP_DIR=./backup
 SWIFT_APPLICATION_CREDENTIAL_ID=local
 SWIFT_APPLICATION_CREDENTIAL_SECRET=local
 SWIFT_CONTAINER_NAME=archive-linkevents
+SWIFT_CONTAINER_AGGREGATES=archive-aggregates
 # See the readme file for setting up a local swift store
 # In production, it should use the known URL https://openstack.eqiad1.wikimediacloud.org:25000/v3
 OPENSTACK_AUTH_URL=http://externallinks-swift:5001/v3


### PR DESCRIPTION
## Description
Added a new environment variable to make a distinction between the Object Storage container that stores the archived link events and the one that will store archived aggregates.

## Rationale
To distinguish between the two container names where we upload the archives.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
