### PR TITLE
Match try/except block structure that we're using for linkevents_archive

### DIFF
--- a/extlinks/aggregates/management/helpers/aggregate_archive_command.py
+++ b/extlinks/aggregates/management/helpers/aggregate_archive_command.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Type, cast
 from django.core import serializers
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError, CommandParser
-from django.db import models
+from django.db import models, close_old_connections
 
 from extlinks.common import swift
 
@@ -153,6 +153,8 @@ class AggregateArchiveCommand(ABC, BaseCommand):
         elif subcommand == "upload":
             self.upload(container=options["container"], filenames=options["filenames"])
 
+        close_old_connections()
+
     def dump(
         self,
         start: Optional[datetime.date] = None,
@@ -202,7 +204,7 @@ class AggregateArchiveCommand(ABC, BaseCommand):
                 end = (datetime.date.today() - relativedelta(years=1)).replace(day=1)
 
         if not container:
-            container = os.environ.get("SWIFT_CONTAINER_AGGREGATES")
+            container = os.environ.get("SWIFT_CONTAINER_AGGREGATES", "archive-aggregates")
 
         if end:
             cursor = start
@@ -286,25 +288,32 @@ class AggregateArchiveCommand(ABC, BaseCommand):
             return False
 
         try:
-            was_created = swift.ensure_container_exists(conn, container)
-            if was_created:
-                self.log_msg(f"Created new container: {container}")
-        except RuntimeError as e:
-            self.log_msg(str(e), level="error")
-            return False
+            # Ensure the container exists before uploading.
+            try:
+                was_created = swift.ensure_container_exists(conn, container)
+                if was_created:
+                    self.log_msg(f"Created new container: {container}")
+            except RuntimeError as e:
+                self.log_msg(str(e), level="error")
+                return False
 
-        successful, failed = swift.batch_upload_files(conn, container, filenames)
+            successful, failed = swift.batch_upload_files(conn, container, filenames)
 
-        self.log_msg(
-            "Uploaded %d/%d archives to object storage",
-            len(successful),
-            len(filenames),
-        )
-
-        if len(failed) > 0:
-            raise CommandError(
-                f"The following {failed} archives failed to upload: {','.join(failed)}"
+            self.log_msg(
+                "Uploaded %d/%d archives to object storage",
+                len(successful),
+                len(filenames),
             )
+
+            if len(failed) > 0:
+                raise CommandError(
+                    f"The following {failed} archives failed to upload: {','.join(failed)}"
+                )
+        except Exception as e:
+            self.log_msg(
+                f"Failed to upload to Swift: {e}", level="error"
+            )
+            return False
 
     def archive(
         self,


### PR DESCRIPTION
Bug: T396681
Change-Id: I575614f739357850752be5d45441f58a1e8db5fe

## Description
Matching the try/except block structure with how we're doing it in linkevents_archive.py. 

## Rationale
We're seeing strange auth exceptions despite using the exact same `get_containers` method call. 

## Phabricator Ticket
https://phabricator.wikimedia.org/T396681

## How Has This Been Tested?
Run tests locally, run commands locally. 

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
