### PR TITLE
Create banners to indicate wrong data on Wikilink

### DIFF
--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -16,6 +16,15 @@
       </ul>
     </nav>
     <nav id="content" class="charts-body">
+      {% if messages %}
+        <div class="messages">
+            {% for message in messages %}
+                <h3>
+                    {{ message }}
+                </h3>
+            {% endfor %}
+        </div>
+      {% endif %}
       <div class="row">
         <div class="col-6">
           <h1>{{ object }}</h1>

--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -52,6 +52,7 @@ class OrganisationDetailView(DetailView):
             self.request,
             "We have modified where Wikilink obtains its data from. Since some of this work is "
             "still in flight, the data shown in Wikilink is currently erroneous. ",
+            fail_silently=True,
         )
         context = super(OrganisationDetailView, self).get_context_data(**kwargs)
         form = self.form_class(self.request.GET)

--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -2,6 +2,7 @@ from datetime import datetime, date, timedelta
 import json
 import re
 
+from django.contrib import messages
 from django.db.models import Count, Sum, Q, Prefetch, CharField
 from django.db.models.functions import Cast
 from django.http import JsonResponse
@@ -47,6 +48,11 @@ class OrganisationDetailView(DetailView):
     # This is almost, but not exactly, the same as the program view.
     # As such, most context gathering is split out to a helper.
     def get_context_data(self, **kwargs):
+        messages.warning(
+            self.request,
+            "We have modified where Wikilink obtains its data from. Since some of this work is "
+            "still in flight, the data shown in Wikilink is currently erroneous. ",
+        )
         context = super(OrganisationDetailView, self).get_context_data(**kwargs)
         form = self.form_class(self.request.GET)
         context["form"] = form
@@ -76,7 +82,9 @@ class OrganisationDetailView(DetailView):
             context["collections"][collection_key] = {}
             context["collections"][collection_key]["object"] = collection
             context["collections"][collection_key]["collection_id"] = collection.pk
-            context["collections"][collection_key]["urls"] = collection.get_url_patterns()
+            context["collections"][collection_key][
+                "urls"
+            ] = collection.get_url_patterns()
 
             context["collections"][collection_key] = (
                 self._build_collection_context_dictionary(

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -13,6 +13,15 @@
       </ul>
     </nav>
     <nav id="content" class="charts-body">
+      {% if messages %}
+        <div class="messages">
+            {% for message in messages %}
+                <h3>
+                    {{ message }}
+                </h3>
+            {% endfor %}
+        </div>
+    {% endif %}
       <div class="row">
         <div class="col-6">
           <h1>{{ object }}</h1>

--- a/extlinks/programs/views.py
+++ b/extlinks/programs/views.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 import json
 
+from django.contrib import messages
 from django.db.models import Sum, Count, Q
 from django.http import JsonResponse
 from django.views.generic import ListView, DetailView
@@ -42,6 +43,11 @@ class ProgramDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ProgramDetailView, self).get_context_data(**kwargs)
+        messages.warning(
+            self.request,
+            "We have modified where Wikilink obtains its data from. Since some of this work is "
+            "still in flight, the data shown in Wikilink is currently erroneous. ",
+        )
         this_program_organisations = self.object.organisation_set.all()
         context["organisations"] = this_program_organisations
         context["program_id"] = self.object.pk

--- a/extlinks/programs/views.py
+++ b/extlinks/programs/views.py
@@ -47,6 +47,7 @@ class ProgramDetailView(DetailView):
             self.request,
             "We have modified where Wikilink obtains its data from. Since some of this work is "
             "still in flight, the data shown in Wikilink is currently erroneous. ",
+            fail_silently=True,
         )
         this_program_organisations = self.object.organisation_set.all()
         context["organisations"] = this_program_organisations

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -123,3 +123,9 @@ hr {
     border-top-color: #9a9a9a;
     border-top-width: 4px;
 }
+
+.messages{
+    display: flex;
+    justify-content: center;
+    margin: 2rem;
+}

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -128,4 +128,8 @@ hr {
     display: flex;
     justify-content: center;
     margin: 2rem;
+    background-color: #fdf2d5;
+    border-style: solid;
+    border-width: 0.25em;
+    border-color: #fbe2a2;
 }


### PR DESCRIPTION
Bug: T399763
Change-Id: I57dbcbfd3f989728bbb2cfc9fd9b802fce394fcf

## Description
While working on [T370980: Export aggregates to static files](https://phabricator.wikimedia.org/T370980), [T396681: Create cron tasks for archiving aggregates](https://phabricator.wikimedia.org/T396681), we have modified where Wikilink obtains its data from. Since some of this work is still in flight, the data shown in Wikilink is erroneous. We should create several banners in organisations/ and programs/ to let the users know that the data shown at this time is inaccurate.

The banners should be removed once we merge the remaining PRs and verify that the data is correct again.
## Rationale
Informs users of ongoing maintenance. 

## Phabricator Ticket
https://phabricator.wikimedia.org/T399763

## How Has This Been Tested?
Tested locally

## Screenshots of your changes (if appropriate):
<img width="2361" height="257" alt="Screenshot 2025-07-16 at 4 19 54 PM" src="https://github.com/user-attachments/assets/86e61044-653a-4223-945f-82451ee8c591" />


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
