### PR TITLE
Create a management command that uploads all archived aggregates

### DIFF
--- a/extlinks/aggregates/management/commands/upload_all_archived_aggregates.py
+++ b/extlinks/aggregates/management/commands/upload_all_archived_aggregates.py
@@ -1,0 +1,21 @@
+import os
+
+from extlinks.common.management.commands import BaseCommand
+from django.core.management import call_command
+
+
+class Command(BaseCommand):
+    help = "Uploads all aggregate archives currently located in the backup directory to object storage"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dir", help="The directory from which to upload archives.", type=str
+        )
+
+    def _handle(self, *args, **options):
+        path = options["dir"]
+        for filename in os.listdir(path):
+            if filename.endswith(".json.gz") and filename.startswith("aggregates_"):
+                file_path = os.path.join(path, filename)
+                if os.path.isfile(file_path):
+                    call_command("archive_link_aggregates", "upload", file_path)

--- a/extlinks/common/swift.py
+++ b/extlinks/common/swift.py
@@ -129,12 +129,15 @@ def upload_file(
     object_name = os.path.basename(path)
 
     with open(path, "rb") as f:
-        conn.put_object(
-            container,
-            object_name,
-            contents=f,
-            content_type=content_type,
-        )
+        if not file_exists(conn, container, object_name):
+            conn.put_object(
+                container,
+                object_name,
+                contents=f,
+                content_type=content_type,
+            )
+        else:
+            return False
 
     return object_name
 
@@ -238,6 +241,8 @@ def batch_upload_files(
 
             try:
                 object_name = future.result()
+                if not object_name:
+                    logger.info(f"Skipping upload for '%s' - already uploaded", path)
                 logger.info(f"Successfully uploaded '%s' as '%s'", path, object_name)
                 successful.append(path)
             except Exception as exc:


### PR DESCRIPTION
## Description
Created a management command that uploads all archived aggregates to Object Storage

## Rationale
If there is an error in uploading archives, we want a way to upload all

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
[T399761](https://phabricator.wikimedia.org/T399761)

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
