### PR TITLE
Wikilink current total for JSTOR is showing incorrect amount

### DIFF
--- a/extlinks/common/helpers.py
+++ b/extlinks/common/helpers.py
@@ -52,11 +52,14 @@ def get_linksearchtotal_data_by_time(queryset, start_date=None, end_date=None):
             current_date = month_first - timedelta(days=1)
 
         # If a month has no data for some reason, we should use whatever
-        # figure we have for the previous month, unless it is the current month
+        # figure we have for the previous month
         for i, data in enumerate(linksearch_data):
-            if data == 0 and i != len(linksearch_data) - 1:
-                linksearch_data[i] = linksearch_data[i + 1]
-
+            linksearch_data_length = len(linksearch_data)
+            if data == 0 and i != linksearch_data_length - 1:
+                for j in range(i + 1, linksearch_data_length):
+                    if linksearch_data[j] != 0:
+                        linksearch_data[i] = linksearch_data[j]
+                        break
         return dates[::-1], linksearch_data[::-1]
     else:
         return [], []

--- a/extlinks/common/tests.py
+++ b/extlinks/common/tests.py
@@ -53,6 +53,7 @@ class LinkSearchDataByTimeTest(TestCase):
 
             self.assertEqual(12, len(dates))
             self.assertEqual(12, len(linksearch_data))
+            self.assertNotIn(0, linksearch_data)
 
     def test_linksearch_start_date_before_current_day(self):
         with time_machine.travel(date(2020, 4, 29)):

--- a/extlinks/links/helpers.py
+++ b/extlinks/links/helpers.py
@@ -3,30 +3,6 @@ from urllib.parse import unquote
 from .models import URLPattern
 
 
-def split_url_for_query(url):
-    """
-    Given a URL pattern, split it into two components:
-    url_optimised: URL and domain name in the el_index format
-    (https://www.mediawiki.org/wiki/Manual:Externallinks_table#el_index)
-    url_pattern_end: Anything following the domain name
-    """
-    url = url.strip()  # Catch any trailing spaces
-    # Start after *. if present
-    if url.startswith("*."):
-        url = url[2:]
-
-    url_start = url.split("/")[0].split(".")[::-1]
-    url_optimised = ".".join(url_start) + ".%"
-
-    if "/" in url:
-        url_end = "/".join(url.split("/")[1:])
-        url_pattern_end = "%./" + url_end + "%"
-    else:
-        url_pattern_end = "%"
-
-    return url_optimised, url_pattern_end
-
-
 def link_is_tracked(link):
     all_urlpatterns = URLPattern.objects.all()
     tracked_links_list = list(all_urlpatterns.values_list("url", flat=True))

--- a/extlinks/links/helpers.py
+++ b/extlinks/links/helpers.py
@@ -3,6 +3,9 @@ from urllib.parse import unquote
 from .models import URLPattern
 
 
+def reverse_host(host):
+    return '.'.join(list(reversed(host.split("."))))
+
 def link_is_tracked(link):
     all_urlpatterns = URLPattern.objects.all()
     tracked_links_list = list(all_urlpatterns.values_list("url", flat=True))

--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -124,7 +124,9 @@ class Command(BaseCommand):
                         self._add_linkevent_to_db(unquoted_url, change, event_dict)
 
     def _add_linkevent_to_db(self, link, change, event_data):
-        if "Z" in event_data["meta"]["dt"]:
+        if "." in event_data["meta"]["dt"]:
+            string_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+        elif "Z" in event_data["meta"]["dt"]:
             string_format = "%Y-%m-%dT%H:%M:%SZ"
         else:
             string_format = "%Y-%m-%dT%H:%M:%S+00:00"

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -20,44 +20,11 @@ from extlinks.organisations.factories import (
     UserFactory,
 )
 from .factories import LinkEventFactory, URLPatternFactory
-from .helpers import link_is_tracked, split_url_for_query
+from .helpers import link_is_tracked
 from .models import URLPattern, LinkEvent
 
 
 class LinksHelpersTest(TestCase):
-    def test_split_url_for_query_1(self):
-        """
-        Given a URL pattern, ensure that our helper function converts it
-        to the expected format for querying replica databases
-        """
-        url = "testurl.com"
-
-        output = split_url_for_query(url)
-
-        self.assertEqual(output, ("com.testurl.%", "%"))
-
-    def test_split_url_for_query_2(self):
-        """
-        Given a URL pattern with a path, ensure that our helper function
-        converts it to the expected format for querying replica databases
-        """
-        url = "testurl.com/test"
-
-        output = split_url_for_query(url)
-
-        self.assertEqual(output, ("com.testurl.%", "%./test%"))
-
-    def test_split_url_for_query_3(self):
-        """
-        Given a URL pattern starting "*.", ensure that our helper function
-        converts it to the expected format for querying replica databases
-        """
-        url = "*.testurl.com/test"
-
-        output = split_url_for_query(url)
-
-        self.assertEqual(output, ("com.testurl.%", "%./test%"))
-
     def test_get_organisation(self):
         """
         Test the get_organisation function on the LinkEvent model.

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -20,11 +20,25 @@ from extlinks.organisations.factories import (
     UserFactory,
 )
 from .factories import LinkEventFactory, URLPatternFactory
-from .helpers import link_is_tracked
+from .helpers import link_is_tracked, reverse_host
 from .models import URLPattern, LinkEvent
 
 
 class LinksHelpersTest(TestCase):
+    def test_reverse_host(self):
+        """
+        Test the reverse_host function in helpers.py.
+        """
+        host = "www.test.org"
+        expected_host = "org.test.www"
+        actual = reverse_host(host)
+        self.assertEqual(expected_host, actual)
+
+        host = "test.com"
+        expected_host = "com.test"
+        actual = reverse_host(host)
+        self.assertEqual(expected_host, actual)
+
     def test_get_organisation(self):
         """
         Test the get_organisation function on the LinkEvent model.
@@ -226,6 +240,51 @@ class LinkEventsCollectCommandTest(TestCase):
                 },
             ],
         }
+        self.event_data3 = {
+            "$schema": "/mediawiki/page/links-change/1.0.0",
+            "meta": {
+                "uri": "https://en.wikipedia.org/wiki/Tanya_Tuzova",
+                "request_id": "db830ce7-1aa8-4984-baa3-7598ea7113d2",
+                "id": "4100e9a8-af77-405f-ab13-ec0957a7c24c",
+                "dt": "2020-08-20T21:22:46.998Z",
+                "domain": "en.wikipedia.org",
+                "stream": "mediawiki.page-links-change",
+                "topic": "eqiad.mediawiki.page-links-change",
+                "partition": 0,
+                "offset": 840218818,
+            },
+            "database": "enwiki",
+            "page_id": 63608061,
+            "page_title": "Page1",
+            "page_namespace": 0,
+            "page_is_redirect": False,
+            "rev_id": 974060041,
+            "performer": {
+                "user_text": "User1",
+                "user_groups": ["extendedconfirmed", "*", "user", "autoconfirmed"],
+                "user_is_bot": False,
+                "user_id": 32001896,
+                "user_registration_dt": "2017-09-24T15:12:43Z",
+                "user_edit_count": 6550,
+            },
+            "added_links": [
+                {
+                    "link": "/wiki/Wikipedia:Articles_for_deletion/Tanya_Tuzova",
+                    "external": False,
+                },
+                {"link": "/wiki/Wikipedia:Deletion_policy", "external": False},
+                {"link": "/wiki/Wikipedia:Guide_to_deletion", "external": False},
+                {"link": "/wiki/Wikipedia:Page_blanking", "external": False},
+                {
+                    "link": "https://www-jstor-org.wikipedialibrary.idm.oclc.org/stable/27903775?Search=yes&resultItemClick=true&searchText=%22Evil+as+an+Explanatory+Concept%22&searchUri=/action/doBasicSearch?Query%3D%2522Evil%2Bas%2Ban%2BExplanatory%2BConcept%2522%26acc%3Don%26wc%3Don%26fc%3Doff%26group%3Dnone%26refreqid%3Dsearch%253Aad56779891b6147f11436f1629fe704d&ab_segments=0/basic_SYC-5187_SYC-5188/5188&refreqid=fastly-default:21cde56a64c1528014fba9e12d054b80&seq=1#metadata_info_tab_contents",
+                    "external": True,
+                },
+                {
+                    "link": "https://www-jstor-org.wikipedialibrary.idm.oclc.org/stable/dklsajdlkajslkdjaslkdjalks",
+                    "external": True,
+                },
+            ],
+        }
 
     def test_management_command_non_proxy(self):
         self.assertEqual(LinkEvent.objects.count(), 0)
@@ -239,6 +298,11 @@ class LinkEventsCollectCommandTest(TestCase):
             call_command("linkevents_collect", test=self.event_data2)
         self.assertEqual(LinkEvent.objects.count(), 2)
 
+    def test_management_command_dates_with_micro_seconds(self):
+        self.assertEqual(LinkEvent.objects.count(), 0)
+        with self.assertRaises(SystemExit):
+            call_command("linkevents_collect", test=self.event_data3)
+        self.assertEqual(LinkEvent.objects.count(), 2)
 
 class LinkEventsArchiveCommandTest(TransactionTestCase):
     def setUp(self):


### PR DESCRIPTION
Bug: T401431
Change-Id: I6eaf43642a11fb1665cb8014774d180297db36d5

## Description
- fixed bug where we were setting current total to the previous month but now we're accounting for if the previous month is also 0
-  Note: this does not address why we're having so many `linksearchtotal_collect.py` return 0 for JSTOR & other partners
- fixed URL parsing in linksearchtotal_collect.py

## Rationale
- Showing 0 for current total due to multiple runs of `linksearchtotal_collect` crons returning 0 in production. 

## Phabricator Ticket
https://phabricator.wikimedia.org/T401431

## How Has This Been Tested?
Added to the existing unit test to ensure 0's are replaced with previous non-zero value. 
**_Note: I cannot test the updated query locally so I would love it if a reviewer could do that, or explain to me how to connect to the replica? I have updated my .env file with the appropriate credentials._** 

## Screenshots of your changes (if appropriate):
Before: 
<img width="1628" height="970" alt="Screenshot 2025-08-14 at 10 00 03 AM" src="https://github.com/user-attachments/assets/1a00253b-ded2-4edf-a714-2c793dbdec3f" />

After: 
<img width="2799" height="960" alt="Screenshot 2025-08-14 at 9 59 39 AM" src="https://github.com/user-attachments/assets/3c7aa2ac-e3fb-4a68-a3bb-ed3fcf323fb1" />

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
