### PR TITLE
Add JSONDecodeError handling and return empty list

### DIFF
--- a/extlinks/aggregates/storage.py
+++ b/extlinks/aggregates/storage.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+from json import JSONDecodeError
 
 from typing import Callable, Dict, Hashable, Iterable, List, Optional, Set
 
@@ -81,7 +82,15 @@ def decode_archive(archive: bytes) -> List[Dict]:
     Decodes a gzipped archive into a list of dictionaries (row records).
     """
     if archive is not None:
-        return json.loads(gzip.decompress(archive))
+        try:
+            decompressed_archive = gzip.decompress(archive)
+            return json.loads(decompressed_archive)
+        except JSONDecodeError as e:
+            logger.error(f"Failed to decode archive {e}")
+            return []
+        except Exception as e:
+            logger.error(f"Failed to decode archive {e}")
+            return []
 
 
 def download_aggregates(

--- a/extlinks/aggregates/storage.py
+++ b/extlinks/aggregates/storage.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import re
-from json import JSONDecodeError
+import string
 
 from typing import Callable, Dict, Hashable, Iterable, List, Optional, Set
 
@@ -81,16 +81,14 @@ def decode_archive(archive: bytes) -> List[Dict]:
     """
     Decodes a gzipped archive into a list of dictionaries (row records).
     """
-    if archive is not None:
-        try:
-            decompressed_archive = gzip.decompress(archive)
-            return json.loads(decompressed_archive)
-        except JSONDecodeError as e:
-            logger.error(f"Failed to decode archive {e}")
-            return []
-        except Exception as e:
-            logger.error(f"Failed to decode archive {e}")
-            return []
+    if archive is None or not isinstance(archive, (bytes, bytearray)):
+        return []
+
+    decompressed_archive = gzip.decompress(archive)
+    if decompressed_archive is None or not isinstance(decompressed_archive, string):
+        return []
+
+    return json.loads(decompressed_archive)
 
 
 def download_aggregates(


### PR DESCRIPTION
Bug: T401431
Change-Id: Ic756e48b2080613489529c581f2b106591bdf70f

## Description
Describe your changes in detail following the [commit message guidelines]

- Added a guard clause type check before attempting to decompress our archive
- Added a guard clause type check before attempting to json load our decompressed archive

## Rationale
JSONDecodeError being thrown when decompression fails. 

## Phabricator Ticket
https://phabricator.wikimedia.org/T401431

## How Has This Been Tested?
Manually tested, and ran unit tests. 

## Screenshots of your changes (if appropriate):

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
