### PR TITLE
Create banners to indicate wrong data on Wikilink

### DIFF
--- a/extlinks/organisations/templates/organisations/organisation_detail.html
+++ b/extlinks/organisations/templates/organisations/organisation_detail.html
@@ -16,15 +16,6 @@
       </ul>
     </nav>
     <nav id="content" class="charts-body">
-      {% if messages %}
-        <div class="messages">
-            {% for message in messages %}
-                <h3>
-                    {{ message }}
-                </h3>
-            {% endfor %}
-        </div>
-      {% endif %}
       <div class="row">
         <div class="col-6">
           <h1>{{ object }}</h1>

--- a/extlinks/organisations/views.py
+++ b/extlinks/organisations/views.py
@@ -5,7 +5,6 @@ from datetime import datetime, date, timedelta
 from logging import getLogger
 
 from dateutil.relativedelta import relativedelta
-from django.contrib import messages
 from django.db.models import Count, Sum, Q, Prefetch, CharField
 from django.db.models.functions import Cast
 from django.http import JsonResponse
@@ -61,12 +60,6 @@ class OrganisationDetailView(DetailView):
     # This is almost, but not exactly, the same as the program view.
     # As such, most context gathering is split out to a helper.
     def get_context_data(self, **kwargs):
-        messages.warning(
-            self.request,
-            "We have modified where Wikilink obtains its data from. Since some of this work is "
-            "still in flight, the data shown in Wikilink is currently erroneous. ",
-            fail_silently=True,
-        )
         context = super(OrganisationDetailView, self).get_context_data(**kwargs)
         form = self.form_class(self.request.GET)
         context["form"] = form

--- a/extlinks/programs/templates/programs/program_detail.html
+++ b/extlinks/programs/templates/programs/program_detail.html
@@ -13,15 +13,6 @@
       </ul>
     </nav>
     <nav id="content" class="charts-body">
-      {% if messages %}
-        <div class="messages">
-            {% for message in messages %}
-                <h3>
-                    {{ message }}
-                </h3>
-            {% endfor %}
-        </div>
-    {% endif %}
       <div class="row">
         <div class="col-6">
           <h1>{{ object }}</h1>

--- a/extlinks/programs/views.py
+++ b/extlinks/programs/views.py
@@ -1,5 +1,4 @@
 import json
-import json
 
 from datetime import date, timedelta, datetime
 from logging import getLogger
@@ -7,7 +6,6 @@ from logging import getLogger
 from datetime import date, timedelta
 from logging import getLogger
 
-from django.contrib import messages
 from django.db.models import Sum, Count, Q
 from django.http import JsonResponse
 from django.views.generic import ListView, DetailView
@@ -48,12 +46,6 @@ class ProgramDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ProgramDetailView, self).get_context_data(**kwargs)
-        messages.warning(
-            self.request,
-            "We have modified where Wikilink obtains its data from. Since some of this work is "
-            "still in flight, the data shown in Wikilink is currently erroneous. ",
-            fail_silently=True,
-        )
         this_program_organisations = self.object.organisation_set.all()
         context["organisations"] = this_program_organisations
         context["program_id"] = self.object.pk

--- a/static/css/local.css
+++ b/static/css/local.css
@@ -123,13 +123,3 @@ hr {
     border-top-color: #9a9a9a;
     border-top-width: 4px;
 }
-
-.messages{
-    display: flex;
-    justify-content: center;
-    margin: 2rem;
-    background-color: #fdf2d5;
-    border-style: solid;
-    border-width: 0.25em;
-    border-color: #fbe2a2;
-}


### PR DESCRIPTION
-Remove banner now that data is stable

Bug: T399763
Change-Id: I3557b0081c44074c577607afb48e87ec874c48a1

## Description
Removed informational banners 

## Rationale
Data is mostly stable, so we can remove the informational banners

## Phabricator Ticket
https://phabricator.wikimedia.org/T399763

## How Has This Been Tested?
Manually smoke tested this locally

## Screenshots of your changes (if appropriate):
<img width="3335" height="1005" alt="Screenshot 2025-08-20 at 8 55 07 AM" src="https://github.com/user-attachments/assets/b63d5b82-c0d6-42e3-9b66-aca15f947732" />

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
