### PR TITLE
Wikilink current total for JSTOR is showing incorrect amount

### DIFF
--- a/extlinks/common/templates/common/statistics_table.html
+++ b/extlinks/common/templates/common/statistics_table.html
@@ -25,11 +25,12 @@
           <td style="text-align: right;">{{ collection.linksearch_total_start }}</td>
         </tr>
         <tr>
-          <td>Total</td>
+          <td>Total
+            {% if collection.as_of_date %}
+              as of {{ collection.as_of_date  }}:
+            {% endif %}
+          </td>
           <td style="text-align: right;">{{ collection.linksearch_total_current }}
-         {% if collection.as_of_date %}
-            as of {{ collection.as_of_date  }}
-         {% endif %}
         </td>
         </tr>
         <tr style="line-height:55px;">


### PR DESCRIPTION
- Fixed label formatting

Bug: T401431
Change-Id: I35ecc95d91bb01d1c670d828c8006296634d4957

## Description
The "as of" date should be part of the "total" label rather than being part of the value.

## Rationale
More user-friendly UI. 

## Phabricator Ticket
https://phabricator.wikimedia.org/T401431

## How Has This Been Tested?
Smoke tested this locally.

## Screenshots of your changes (if appropriate):
changed: 
<img width="715" height="218" alt="Screenshot 2025-08-20 at 2 58 18 PM" src="https://github.com/user-attachments/assets/503eba59-9f86-4e8e-8ec0-98cde8386ae7" />

to: 
<img width="763" height="328" alt="Screenshot 2025-08-20 at 2 58 22 PM" src="https://github.com/user-attachments/assets/6fd9f418-1c7a-4362-8021-f25a20e45d5e" />

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
