### PR TITLE
management command logging & locking cleanup

### DIFF
--- a/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
+++ b/extlinks/aggregates/management/commands/fill_monthly_link_aggregates.py
@@ -1,7 +1,6 @@
-import calendar
+import calendar, logging
 from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
-import logging
 
 from extlinks.common.management.commands import BaseCommand
 from django.core.management.base import CommandError
@@ -16,13 +15,6 @@ logger = logging.getLogger("django")
 
 class Command(BaseCommand):
     help = "Adds monthly aggregated data into the LinkAggregate table"
-
-    def info(self, msg):
-        # Log and print so that messages are visible
-        # in docker logs (log) and cron job logs (print)
-        logger.info(msg)
-        self.stdout.write(msg)
-        self.stdout.flush()
 
     def add_arguments(self, parser):
         # Option to filter by specific collection(s)
@@ -49,7 +41,7 @@ class Command(BaseCommand):
         run by specific collection, year/month, or a full scan of the
         historic data.
         """
-        self.info("Monthly LinkAggregate job started")
+        logger.info("Monthly LinkAggregate job started")
 
         if options["year_month"]:
             try:
@@ -69,7 +61,7 @@ class Command(BaseCommand):
             try:
                 oldest_agg = LinkAggregate.objects.exclude(day=0).earliest("full_date")
             except LinkAggregate.DoesNotExist:
-                self.info("No data to process.")
+                logger.info("No data to process.")
                 return
             oldest_date = oldest_agg.full_date
             monthrange = calendar.monthrange(oldest_date.year, oldest_date.month)
@@ -77,12 +69,12 @@ class Command(BaseCommand):
             last_day_of_month = oldest_date.replace(day=monthrange[1])
             no_later_than_date = today - timedelta(days=10)
             if last_day_of_month > no_later_than_date:
-                self.info(
+                logger.info(
                     f"No data within allowed date range: {no_later_than_date} falls within the month of {oldest_date}"
                 )
                 return
 
-        self.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
+        logger.info(f"Processing data from {first_day_of_month} to {last_day_of_month}")
         month_filter = Q(
             full_date__gte=first_day_of_month, full_date__lte=last_day_of_month
         )
@@ -93,7 +85,7 @@ class Command(BaseCommand):
         else:
             self._process_aggregation(month_filter)
 
-        self.info("Monthly LinkAggregate job ended")
+        logger.info("Monthly LinkAggregate job ended")
         close_old_connections()
 
     def _process_aggregation(self, main_filter_query):
@@ -115,7 +107,7 @@ class Command(BaseCommand):
         -------
         None
         """
-        self.info("Fetching the main query")
+        logger.info("Fetching the main query")
 
         aggregated_data = (
             LinkAggregate.objects.filter(main_filter_query)
@@ -140,11 +132,11 @@ class Command(BaseCommand):
         for batch_index, batch in enumerate(batch_iterator(aggregated_data), start=1):
             with transaction.atomic():
                 total_aggregations += len(batch)
-                self.info(f"Processing batch {batch_index} (size: {len(batch)})")
+                logger.info(f"Processing batch {batch_index} (size: {len(batch)})")
                 for monthly_aggregation in batch:
                     self._verify_and_save_aggregation(monthly_aggregation)
 
-        self.info(f"Processed a total of {total_aggregations} monthly aggregations")
+        logger.info(f"Processed a total of {total_aggregations} monthly aggregations")
 
     def _verify_and_save_aggregation(self, monthly_aggregation):
         """

--- a/extlinks/aggregates/management/commands/fill_top_organisations_totals.py
+++ b/extlinks/aggregates/management/commands/fill_top_organisations_totals.py
@@ -1,15 +1,14 @@
-import calendar
-import datetime
-import logging
+import calendar, datetime, logging
 
 from typing import Any, Dict, List, Optional, Tuple
 
 from dateutil.relativedelta import relativedelta
-from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.core.management.base import CommandError, CommandParser
 from django.db.models.aggregates import Sum
 from django.db.models.expressions import F
 
 from extlinks.aggregates.models import LinkAggregate, ProgramTopOrganisationsTotal
+from extlinks.common.management.commands import BaseCommand
 from extlinks.programs.models import Program
 
 logger = logging.getLogger("django")

--- a/extlinks/aggregates/management/commands/fill_top_projects_totals.py
+++ b/extlinks/aggregates/management/commands/fill_top_projects_totals.py
@@ -1,15 +1,14 @@
-import calendar
-import datetime
-import logging
+import calendar, datetime, logging
 
 from typing import Any, Dict, List, Optional, Tuple
 
 from dateutil.relativedelta import relativedelta
-from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.core.management.base import CommandError, CommandParser
 from django.db.models.aggregates import Sum
 from django.db.models.expressions import F
 
 from extlinks.aggregates.models import PageProjectAggregate, ProgramTopProjectsTotal
+from extlinks.common.management.commands import BaseCommand
 from extlinks.programs.models import Program
 
 logger = logging.getLogger("django")

--- a/extlinks/aggregates/management/commands/fill_top_users_totals.py
+++ b/extlinks/aggregates/management/commands/fill_top_users_totals.py
@@ -1,15 +1,14 @@
-import calendar
-import datetime
-import logging
+import calendar, datetime, logging
 
 from typing import Any, Dict, List, Optional, Tuple
 
 from dateutil.relativedelta import relativedelta
-from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.core.management.base import CommandError, CommandParser
 from django.db.models.aggregates import Sum
 from django.db.models.expressions import F
 
 from extlinks.aggregates.models import ProgramTopUsersTotal, UserAggregate
+from extlinks.common.management.commands import BaseCommand
 from extlinks.programs.models import Program
 
 logger = logging.getLogger("django")

--- a/extlinks/aggregates/management/helpers/aggregate_archive_command.py
+++ b/extlinks/aggregates/management/helpers/aggregate_archive_command.py
@@ -10,10 +10,11 @@ from typing import List, Optional, Type, cast
 
 from django.core import serializers
 from django.core.management import call_command
-from django.core.management.base import BaseCommand, CommandError, CommandParser
+from django.core.management.base import CommandError, CommandParser
 from django.db import models, close_old_connections
 
 from extlinks.common import swift
+from extlinks.common.management.commands import BaseCommand
 
 logger = logging.getLogger("django")
 

--- a/extlinks/common/management/commands/__init__.py
+++ b/extlinks/common/management/commands/__init__.py
@@ -1,6 +1,7 @@
 from django.core.management.base import BaseCommand as DjangoBaseCommand
 from filelock import FileLock
 import inspect
+import logging
 from os import remove
 from os.path import basename
 

--- a/extlinks/settings/logging.py
+++ b/extlinks/settings/logging.py
@@ -20,7 +20,7 @@ logging.config.dictConfig(
         "formatters": {
             "django.server": {
                 "()": "django.utils.log.ServerFormatter",
-                "format": "[%(server_time)s] %(message)s",
+                "format": "[%(levelname)s] %(message)s",
             }
         },
         "handlers": {
@@ -28,11 +28,13 @@ logging.config.dictConfig(
                 "level": "WARNING",
                 "filters": ["require_debug_false"],
                 "class": "logging.StreamHandler",
+                "formatter": "django.server",
             },
             "debug_console": {
                 "level": "INFO",
                 "filters": ["require_debug_true"],
                 "class": "logging.StreamHandler",
+                "formatter": "django.server",
             },
             "django.server": {
                 "level": "INFO",


### PR DESCRIPTION
## Description
- Add some proper logging to linksearchtotal_collect
    - and exit(1) if db connection fails
- Use the same formatter for all handlers
- Stop using bespoke methods for logging to STDOUT/STDERR
- Use project BaseCommand class for all management commands
    - `extlinks.common.management.commands.BaseCommand` provides locking

## Rationale
We've added management commands with inconsistent logging & locking approaches, making troubleshooting difficult.

## Phabricator Ticket
https://phabricator.wikimedia.org/T403209

## How Has This Been Tested?
- Locally tested by running management commands manually and via crontab

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

cron logs:
```
crons-1  | 2025-09-02T20:06:09.463887909Z [INFO] reading wiki-list
crons-1  | 2025-09-02T20:06:09.464161829Z [INFO] connecting to db en
crons-1  | 2025-09-02T20:06:12.532978752Z [ERROR] (2002, "Can't connect to MySQL server on 'enwiki.analytics.db.svc.wikimedia.cloud' (101)")
```

terminal output from manual run:
```
[INFO] reading wiki-list
[INFO] connecting to db en
[ERROR] (2002, "Can't connect to MySQL server on 'enwiki.analytics.db.svc.wikimedia.cloud' (101)")
```


## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
