### PR TITLE
Fix link for Special:diff

### DIFF
--- a/extlinks/organisations/templates/organisations/organisation_charts_include.html
+++ b/extlinks/organisations/templates/organisations/organisation_charts_include.html
@@ -436,7 +436,7 @@
           tdDomain.innerHTML = latest_link_events[i].domain;
           var tdRev = document.createElement("td");
           var aRev = document.createElement("a");
-          aRev.href = "https://"+latest_link_events[i].domain+"/wiki/Special:Diff" + latest_link_events[i].rev_id;
+          aRev.href = "https://"+latest_link_events[i].domain+"/wiki/Special:Diff/" + latest_link_events[i].rev_id;
           aRev.appendChild(document.createTextNode(latest_link_events[i].date));
           tdRev.appendChild(aRev);
           tr.appendChild(tdLink);


### PR DESCRIPTION
[//]: # (Thank you for uploading a PR to Wikilinks (externallinks)!)

## Description
Fix link for Special:diff

## Rationale
Currently it produces a link like `https://en.wikipedia.org/wiki/Special:Diff1309325641`, which is missing a `/`.

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
